### PR TITLE
Fix missing wake engine handling

### DIFF
--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -195,7 +195,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -139,7 +139,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -95,7 +95,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 

--- a/voice-assistant/quinled-dig2go.yaml
+++ b/voice-assistant/quinled-dig2go.yaml
@@ -95,7 +95,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 

--- a/voice-assistant/raspiaudio-muse-luxe.yaml
+++ b/voice-assistant/raspiaudio-muse-luxe.yaml
@@ -115,7 +115,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 

--- a/voice-assistant/raspiaudio-muse-proto.yaml
+++ b/voice-assistant/raspiaudio-muse-proto.yaml
@@ -107,7 +107,7 @@ voice_assistant:
     - script.execute: reset_led
     - script.wait: reset_led
     - lambda: |-
-        if (code == "wake-provider-missing") {
+        if (code == "wake-provider-missing" || code == "wake-engine-missing") {
           id(use_wake_word).turn_off();
         }
 


### PR DESCRIPTION
`wake-provider-missing` was already handled but `wake-engine-missing` was not, causing a very fast and infinite loop of pipeline starts and stops if the wake-word switch was on inside esphome.