### PR TITLE
Auto populate matrix build from files inside directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 5
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: esphome/build-action@v1.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,32 +22,30 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        firmware:
-          - esp-web-tools
-          - esphome-web
-        device:
-          - esp8266
-          - esp32
-          - esp32c3
-          - esp32s2
-          - esp32s3
-        version:
-          - latest
         include:
           - firmware: esphome-web
-            device: pico-w
+            device:
+              - esp32
+              - esp32c3
+              - esp32s2
+              - esp32s3
+              - esp8266
+              - pico-w
+          - firmware: esp-web-tools
+            device:
+              - esp32
+              - esp32c3
+              - esp32s2
+              - esp32s3
+              - esp8266
           - firmware: voice-assistant
-            device: m5stack-atom-echo
-          - firmware: voice-assistant
-            device: esp32-s3-box
-          - firmware: voice-assistant
-            device: esp32-s3-box-lite
-          - firmware: voice-assistant
-            device: raspiaudio-muse-luxe
-          - firmware: voice-assistant
-            device: raspiaudio-muse-proto
-          - firmware: voice-assistant
-            device: quinled-dig2go
+            device:
+              - m5stack-atom-echo
+              - esp32-s3-box
+              - esp32-s3-box-lite
+              - raspiaudio-muse-luxe
+              - raspiaudio-muse-proto
+              - quinled-dig2go
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,39 +14,41 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FIRMWARES: esp-web-tools esphome-web voice-assistant
+
 jobs:
+  prepare:
+    name: Prepare matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.prepare-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare matrix
+        id: prepare-matrix
+        run: |-
+          firmwares="esp-web-tools esphome-web voice-assistant"
+          matrix=""
+          for firmware in $firmwares; do
+            for device in $firmware/*.yaml; do
+              device=${device##*/}
+              device=${device%.yaml}
+              matrix="$matrix{\"firmware\":\"$firmware\",\"device\":\"$device\"},"
+            done
+          done
+          matrix=${matrix%?}
+          matrix="{\"include\":[$matrix]}"
+          echo matrix=$matrix >> $GITHUB_OUTPUT
+
   build:
     name: ${{ matrix.firmware }}-${{ matrix.device }}
     runs-on: ubuntu-latest
+    needs: prepare
     strategy:
       max-parallel: 5
       fail-fast: false
-      matrix:
-        include:
-          - firmware: esphome-web
-            device:
-              - esp32
-              - esp32c3
-              - esp32s2
-              - esp32s3
-              - esp8266
-              - pico-w
-          - firmware: esp-web-tools
-            device:
-              - esp32
-              - esp32c3
-              - esp32s2
-              - esp32s3
-              - esp8266
-          - firmware: voice-assistant
-            device:
-              - m5stack-atom-echo
-              - esp32-s3-box
-              - esp32-s3-box-lite
-              - raspiaudio-muse-luxe
-              - raspiaudio-muse-proto
-              - quinled-dig2go
-
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}}
     steps:
       - uses: actions/checkout@v4
       - uses: esphome/build-action@v1.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Prepare matrix
         id: prepare-matrix
         run: |-
-          firmwares="esp-web-tools esphome-web voice-assistant"
           matrix=""
-          for firmware in $firmwares; do
+          for firmware in $FIRMWARES; do
             for device in $firmware/*.yaml; do
               device=${device##*/}
               device=${device%.yaml}


### PR DESCRIPTION
The matrix was getting messy with many individual `include` lines, this changes that so that we only need to alter the `FIRMWARES` env var to build all firmwares for that folder.