### PR TITLE
Start voice assistant on api connection

### DIFF
--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -126,6 +126,22 @@ binary_sensor:
             - script.execute: reset_led
             - script.wait: reset_led
             - voice_assistant.start_continuous:
+  - platform: status
+    id: api_connection
+    filters:
+      - delayed_on: 1s
+    on_press:
+      - if:
+          condition:
+            switch.is_on: use_wake_word
+          then:
+            - voice_assistant.start_continuous:
+    on_release:
+      - if:
+          condition:
+            switch.is_on: use_wake_word
+          then:
+            - voice_assistant.stop:
 
 light:
   - platform: esp32_rmt_led_strip


### PR DESCRIPTION
This is a basic way to attempt to restart the voice asssistant with the downside that it will not work correctly if the logs are being followed over the air as this uses the `api` server too