### PR TITLE
Stop led on disconnect, reset LED on connect

### DIFF
--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -215,12 +215,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 script:
   - id: reset_led

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -153,12 +153,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 script:
   - id: reset_led

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -94,12 +94,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 binary_sensor:
   - platform: gpio

--- a/voice-assistant/quinled-dig2go.yaml
+++ b/voice-assistant/quinled-dig2go.yaml
@@ -94,12 +94,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 power_supply:
   - id: led_power

--- a/voice-assistant/raspiaudio-muse-luxe.yaml
+++ b/voice-assistant/raspiaudio-muse-luxe.yaml
@@ -114,12 +114,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 sensor:
   - platform: adc

--- a/voice-assistant/raspiaudio-muse-proto.yaml
+++ b/voice-assistant/raspiaudio-muse-proto.yaml
@@ -116,12 +116,14 @@ voice_assistant:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.start_continuous:
+          - script.execute: reset_led
   on_client_disconnected:
     - if:
         condition:
           switch.is_on: use_wake_word
         then:
           - voice_assistant.stop:
+          - light.turn_off: led  
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
Today if the ESPHome Voice Assistant gets disconnected to Home Assistant, or if it's never integrated into Home Assistant, the light stays Purple as if the device was ready to listen to wake words.

This PR fixes that.
The LED only turns on (using `script.execute: reset_led` when the client is connected, and turns off when it's disconnected)

This means that the purple light is now aligned with the fact that the device is ready to listen to a wake word.

For example, during a HA update, you will see your voice assistant LED turning off because the server is not ready.
