### PR TITLE
Remove deprecated new_install_skip_erase from manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Generate manifest.json
         run: |
           version=$(cat files/*/version | sort -V | tail -n 1)
-          jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' files/*/manifest.json > manifest.json
+          jq -s --arg version "$version" '{"name": "${{ matrix.name }}", "version": $version, "home_assistant_domain": "esphome", "builds":.}' files/*/manifest.json > manifest.json
       - uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ matrix.project }}


### PR DESCRIPTION
The option `new_install_skip_erase` is deprecated in ESP Web Tools. We also set it to the default value so there is no value in setting it. This PR removes it.