### PR TITLE
Use board setting for wt32-eth01

### DIFF
--- a/bluetooth-proxy/wt32-eth01.yaml
+++ b/bluetooth-proxy/wt32-eth01.yaml
@@ -11,7 +11,7 @@ esphome:
     version: "1.0"
 
 esp32:
-  board: esp32doit-devkit-v1
+  board: wt32-eth01
   framework:
     type: esp-idf
 


### PR DESCRIPTION
Platform.io has an explicit profile for this module: https://docs.platformio.org/en/latest/boards/espressif32/wt32-eth01.html