### PR TITLE
Set DIO flash mode for S-variants

### DIFF
--- a/esp-web-tools/esp32s2.yaml
+++ b/esp-web-tools/esp32s2.yaml
@@ -6,6 +6,8 @@ esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  platformio_options:
+    board_build.flash_mode: dio
   project:
     name: esphome.esp_web_tools_example
     version: "1.0"

--- a/esp-web-tools/esp32s3.yaml
+++ b/esp-web-tools/esp32s3.yaml
@@ -6,6 +6,8 @@ esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  platformio_options:
+    board_build.flash_mode: dio
   project:
     name: esphome.esp_web_tools_example
     version: "1.0"

--- a/esphome-web/esp32s2.yaml
+++ b/esphome-web/esp32s2.yaml
@@ -6,6 +6,8 @@ esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  platformio_options:
+    board_build.flash_mode: dio
   project:
     name: esphome.web
     version: "1.0"

--- a/esphome-web/esp32s3.yaml
+++ b/esphome-web/esp32s3.yaml
@@ -6,6 +6,8 @@ esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  platformio_options:
+    board_build.flash_mode: dio
   project:
     name: esphome.web
     version: "1.0"


### PR DESCRIPTION
For Arduino builds on the `S` variants, we need:
```yaml
  platformio_options:
    board_build.flash_mode: dio
```
...to avoid a boot loop.