### PR TITLE
New color scheme for voice assistant

### DIFF
--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -6,7 +6,7 @@ esphome:
   project:
     name: m5stack.atom-echo-voice-assistant
     version: "1.0"
-  min_version: 2023.11.0b5
+  min_version: 2023.11.1
 
 esp32:
   board: m5stack-atom

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -57,14 +57,20 @@ voice_assistant:
         blue: 100%
         red: 0%
         green: 0%
-        brightness: 100%
-        effect: pulse
+        effect: "Slow Pulse"
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Fast Pulse"
   on_tts_start:
     - light.turn_on:
         id: led
+        blue: 100%
         red: 0%
         green: 0%
-        blue: 100%
         brightness: 100%
         effect: none
   on_end:
@@ -140,8 +146,17 @@ light:
     rmt_channel: 0
     effects:
       - pulse:
+          name: "Slow Pulse"
           transition_length: 250ms
           update_interval: 250ms
+          min_brightness: 50%
+          max_brightness: 100%
+      - pulse:
+          name: "Fast Pulse"
+          transition_length: 100ms
+          update_interval: 100ms
+          min_brightness: 50%
+          max_brightness: 100%
 
 script:
   - id: reset_led

--- a/voice-assistant/quinled-dig2go.yaml
+++ b/voice-assistant/quinled-dig2go.yaml
@@ -61,16 +61,22 @@ voice_assistant:
         blue: 100%
         red: 0%
         green: 0%
-        brightness: 100%
-        effect: pulse
+        effect: "Slow Pulse"
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Fast Pulse"
   on_tts_start:
     - light.turn_on:
         id: led
-        blue: 0%
+        blue: 100%
         red: 0%
-        green: 100%
+        green: 0%
         brightness: 100%
-        effect: pulse
+        effect: none
   on_end:
     - script.execute: reset_led
   on_error:
@@ -113,10 +119,24 @@ light:
     power_supply: led_power
     is_rgbw: true
     pin: GPIO16
+    default_transition_length: 250ms
     rgb_order: grb
     chipset: sk6812
     num_leds: 300
     rmt_channel: 2
+    effects:
+      - pulse:
+          name: "Slow Pulse"
+          transition_length: 250ms
+          update_interval: 250ms
+          min_brightness: 50%
+          max_brightness: 100%
+      - pulse:
+          name: "Fast Pulse"
+          transition_length: 100ms
+          update_interval: 100ms
+          min_brightness: 50%
+          max_brightness: 100%
 
 binary_sensor:
   - platform: gpio
@@ -154,10 +174,10 @@ script:
           then:
             - light.turn_on:
                 id: led
-                blue: 100%
                 red: 100%
-                green: 0%
-                brightness: 100%
+                green: 89%
+                blue: 71%
+                brightness: 60%
                 effect: none
           else:
             - light.turn_off: led

--- a/voice-assistant/quinled-dig2go.yaml
+++ b/voice-assistant/quinled-dig2go.yaml
@@ -6,7 +6,7 @@ esphome:
   project:
     name: quinled.dig2go-voice-assistant
     version: "1.0"
-  min_version: 2023.11.0b5
+  min_version: 2023.11.1
 
 esp32:
   board: esp32dev

--- a/voice-assistant/raspiaudio-muse-luxe.yaml
+++ b/voice-assistant/raspiaudio-muse-luxe.yaml
@@ -6,7 +6,7 @@ esphome:
   project:
     name: raspiaudio.muse-luxe-voice-assistant
     version: "1.0"
-  min_version: 2023.11.0b5
+  min_version: 2023.11.1
 
 esp32:
   board: esp-wrover-kit

--- a/voice-assistant/raspiaudio-muse-luxe.yaml
+++ b/voice-assistant/raspiaudio-muse-luxe.yaml
@@ -77,16 +77,22 @@ voice_assistant:
         blue: 100%
         red: 0%
         green: 0%
-        brightness: 100%
-        effect: pulse
+        effect: "Slow Pulse"
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Fast Pulse"
   on_tts_start:
     - light.turn_on:
         id: led
-        blue: 0%
+        blue: 100%
         red: 0%
-        green: 100%
+        green: 0%
         brightness: 100%
-        effect: pulse
+        effect: none
   on_end:
     - delay: 100ms
     - wait_until:
@@ -198,8 +204,17 @@ light:
     gamma_correct: 2.8
     effects:
       - pulse:
+          name: "Slow Pulse"
           transition_length: 250ms
           update_interval: 250ms
+          min_brightness: 50%
+          max_brightness: 100%
+      - pulse:
+          name: "Fast Pulse"
+          transition_length: 100ms
+          update_interval: 100ms
+          min_brightness: 50%
+          max_brightness: 100%
 
 script:
   - id: reset_led
@@ -210,10 +225,10 @@ script:
           then:
             - light.turn_on:
                 id: led
-                blue: 100%
                 red: 100%
-                green: 0%
-                brightness: 100%
+                green: 89%
+                blue: 71%
+                brightness: 60%
                 effect: none
           else:
             - light.turn_off: led

--- a/voice-assistant/raspiaudio-muse-proto.yaml
+++ b/voice-assistant/raspiaudio-muse-proto.yaml
@@ -6,7 +6,7 @@ esphome:
   project:
     name: raspiaudio.muse-proto-voice-assistant
     version: "1.0"
-  min_version: 2023.11.0b5
+  min_version: 2023.11.1
 
 esp32:
   board: esp-wrover-kit

--- a/voice-assistant/raspiaudio-muse-proto.yaml
+++ b/voice-assistant/raspiaudio-muse-proto.yaml
@@ -77,17 +77,23 @@ voice_assistant:
         blue: 100%
         red: 0%
         green: 0%
-        brightness: 100%
-        effect: pulse
+        effect: "Slow Pulse"
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Fast Pulse"
   on_tts_start:
     - output.turn_off: mute_pin
     - light.turn_on:
         id: led
-        blue: 0%
+        blue: 100%
         red: 0%
-        green: 100%
+        green: 0%
         brightness: 100%
-        effect: pulse
+        effect: none
   on_end:
     - delay: 100ms
     - wait_until:
@@ -161,8 +167,17 @@ light:
     rgb_order: grb
     effects:
       - pulse:
+          name: "Slow Pulse"
           transition_length: 250ms
           update_interval: 250ms
+          min_brightness: 50%
+          max_brightness: 100%
+      - pulse:
+          name: "Fast Pulse"
+          transition_length: 100ms
+          update_interval: 100ms
+          min_brightness: 50%
+          max_brightness: 100%
 
 script:
   - id: reset_led
@@ -173,10 +188,10 @@ script:
           then:
             - light.turn_on:
                 id: led
-                blue: 100%
                 red: 100%
-                green: 0%
-                brightness: 100%
+                green: 89%
+                blue: 71%
+                brightness: 60%
                 effect: none
           else:
             - light.turn_off: led


### PR DESCRIPTION
For each of the 4 voice assistant boards with LEDs as visual feedback

I created two effects 

- A "Slow Pulse" for when the device is Listening
- A "Fast Pulse" for when the device is "Processing"

Note that I considered the beginning of the Processing `on_stt_vad_end` so that users with slow STT engine are included

I kept @kbx81 "Warm white settings" for the idle state
