### PR TITLE
Add ble improv and factory reset to VA

### DIFF
--- a/voice-assistant/esp32-s3-box-3.yaml
+++ b/voice-assistant/esp32-s3-box-3.yaml
@@ -50,16 +50,27 @@ logger:
 dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/esp32-s3-box.yaml@main
 
-improv_serial:
-
 wifi:
   ap:
   on_connect:
     then:
       - script.execute: reset_display
+      - delay: 5s # Gives time for improv results to be transmitted
+      - ble.disable:
   on_disconnect:
     then:
       - script.execute: reset_display
+      - ble.enable:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset
 
 binary_sensor:
   - platform: gpio
@@ -75,24 +86,32 @@ binary_sensor:
       inverted: true
     name: Top Left Button
     disabled_by_default: true
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_display
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_display
-            - script.wait: reset_display
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_display
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_display
+                - script.wait: reset_display
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 output:
   - platform: ledc

--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -46,16 +46,27 @@ logger:
 dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/esp32-s3-box-lite.yaml@main
 
-improv_serial:
-
 wifi:
   ap:
   on_connect:
     then:
       - script.execute: reset_display
+      - delay: 5s # Gives time for improv results to be transmitted
+      - ble.disable:
   on_disconnect:
     then:
       - script.execute: reset_display
+      - ble.enable:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset
 
 sensor:
   - platform: adc
@@ -125,24 +136,32 @@ binary_sensor:
       inverted: true
     name: Left Top Button
     disabled_by_default: true
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_display
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_display
-            - script.wait: reset_display
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_display
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_display
+                - script.wait: reset_display
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 output:
   - platform: ledc

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -44,16 +44,26 @@ logger:
 dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/esp32-s3-box.yaml@main
 
-improv_serial:
-
 wifi:
   ap:
   on_connect:
     then:
       - script.execute: reset_display
+      - delay: 5s # Gives time for improv results to be transmitted
+      - ble.disable:
   on_disconnect:
     then:
       - script.execute: reset_display
+      - ble.enable:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    name: Factory reset
 
 binary_sensor:
   - platform: gpio

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -63,6 +63,7 @@ esp32_improv:
 
 button:
   - platform: factory_reset
+    id: factory_reset_btn
     name: Factory reset
 
 binary_sensor:
@@ -79,24 +80,32 @@ binary_sensor:
       inverted: true
     name: Top Left Button
     disabled_by_default: true
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_display
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_display
-            - script.wait: reset_display
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_display
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_display
+                - script.wait: reset_display
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 output:
   - platform: ledc

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -35,6 +35,7 @@ esp32_improv:
 
 button:
   - platform: factory_reset
+    id: factory_reset_btn
     name: Factory reset
 
 i2s_audio:
@@ -125,24 +126,32 @@ binary_sensor:
     disabled_by_default: true
     entity_category: diagnostic
     id: echo_button
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_led
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_led
-            - script.wait: reset_led
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_led
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_led
+                - script.wait: reset_led
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 light:
   - platform: esp32_rmt_led_strip

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -33,6 +33,10 @@ improv_serial:
 esp32_improv:
   authorizer: none
 
+button:
+  - platform: factory_reset
+    name: Factory reset
+
 i2s_audio:
   i2s_lrclk_pin: GPIO33
   i2s_bclk_pin: GPIO19
@@ -214,10 +218,6 @@ switch:
       - script.execute: reset_led
     on_turn_off:
       - script.execute: reset_led
-
-button:
-  - platform: factory_reset
-    name: Factory reset
 
 external_components:
   - source: github://pr#5230

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -21,9 +21,17 @@ dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/m5stack-atom-echo.yaml@main
 
 wifi:
+  on_connect:
+    - delay: 5s # Gives time for improv results to be transmitted
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
   ap:
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 i2s_audio:
   i2s_lrclk_pin: GPIO33
@@ -206,6 +214,10 @@ switch:
       - script.execute: reset_led
     on_turn_off:
       - script.execute: reset_led
+
+button:
+  - platform: factory_reset
+    name: Factory reset
 
 external_components:
   - source: github://pr#5230

--- a/voice-assistant/raspiaudio-muse-luxe.yaml
+++ b/voice-assistant/raspiaudio-muse-luxe.yaml
@@ -25,11 +25,22 @@ dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/raspiaudio-muse-luxe.yaml@main
 
 wifi:
+  on_connect:
+    - delay: 5s # Gives time for improv results to be transmitted
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
   ap:
 
-captive_portal:
-
 improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset
 
 external_components:
   - source: github://pr#3552 # DAC support https://github.com/esphome/esphome/pull/3552
@@ -172,24 +183,32 @@ binary_sensor:
         pullup: true
     name: Action
     disabled_by_default: true
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_led
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_led
-            - script.wait: reset_led
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_led
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_led
+                - script.wait: reset_led
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 light:
   - platform: esp32_rmt_led_strip

--- a/voice-assistant/raspiaudio-muse-proto.yaml
+++ b/voice-assistant/raspiaudio-muse-proto.yaml
@@ -21,11 +21,22 @@ dashboard_import:
   package_import_url: github://esphome/firmware/voice-assistant/raspiaudio-muse-proto.yaml@main
 
 wifi:
+  on_connect:
+    - delay: 5s # Gives time for improv results to be transmitted
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
   ap:
 
-captive_portal:
-
 improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset
 
 external_components:
   - source: github://pr#5230
@@ -136,24 +147,32 @@ binary_sensor:
         pullup: true
     name: Action
     disabled_by_default: true
-    on_click:
-      - if:
-          condition:
-            switch.is_off: use_wake_word
-          then:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_led
-                else:
-                  - voice_assistant.start:
-          else:
-            - voice_assistant.stop
-            - delay: 1s
-            - script.execute: reset_led
-            - script.wait: reset_led
-            - voice_assistant.start_continuous:
+    on_multi_click:
+      - timing:
+          - ON for at least 250ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_off: use_wake_word
+              then:
+                - if:
+                    condition: voice_assistant.is_running
+                    then:
+                      - voice_assistant.stop:
+                      - script.execute: reset_led
+                    else:
+                      - voice_assistant.start:
+              else:
+                - voice_assistant.stop
+                - delay: 1s
+                - script.execute: reset_led
+                - script.wait: reset_led
+                - voice_assistant.start_continuous:
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
 
 light:
   - platform: esp32_rmt_led_strip


### PR DESCRIPTION
This PR adds `esp32_improv` via ble to the configs to allow provisioning Wi-Fi directly from Home Assistant with `bluetooth_proxies`

It also adds a factory reset virtual and hardware button.
The same button used for stopping the Voice Assistant can be held for 10 seconds to factory reset (Remove Wi-Fi credentials)

Device | Added | Tested
-------|-------|-------
Atom Echo | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>
S3 Box | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>
S3 Box Lite | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>
S3 Box 3 | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>
Muse Proto | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>
Muse Luxe | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul>