### PR TITLE
Rename Use Wake Word to Mute

### DIFF
--- a/voice-assistant/esp32-s3-box-3.yaml
+++ b/voice-assistant/esp32-s3-box-3.yaml
@@ -110,6 +110,8 @@ binary_sensor:
       number: GPIO1
       inverted: true
     name: "Mute"
+    disabled_by_default: true
+    entity_category: diagnostic
 
   - platform: gpio
     pin:
@@ -118,6 +120,7 @@ binary_sensor:
       inverted: true
     name: Top Left Button
     disabled_by_default: true
+    entity_category: diagnostic
     on_multi_click:
       - timing:
           - ON for at least 10s
@@ -180,7 +183,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: use_wake_word
+                switch.is_on: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -189,7 +192,7 @@ voice_assistant:
   on_client_connected: 
     - if:
         condition:
-          switch.is_on: use_wake_word
+          switch.is_on: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -260,8 +263,8 @@ script:
 
 switch:
   - platform: template
-    name: Use wake word
-    id: use_wake_word
+    name: Mute
+    id: mute
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     entity_category: config

--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -231,7 +231,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: use_wake_word
+                switch.is_on: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -240,7 +240,7 @@ voice_assistant:
   on_client_connected:
     - if:
         condition:
-          switch.is_on: use_wake_word
+          switch.is_on: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -312,8 +312,8 @@ script:
 
 switch:
   - platform: template
-    name: Use wake word
-    id: use_wake_word
+    name: Mute
+    id: mute
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     entity_category: config

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -104,6 +104,8 @@ binary_sensor:
       number: GPIO1
       inverted: true
     name: "Mute"
+    disabled_by_default: true
+    entity_category: diagnostic
 
   - platform: gpio
     pin:
@@ -112,6 +114,7 @@ binary_sensor:
       inverted: true
     name: Top Left Button
     disabled_by_default: true
+    entity_category: diagnostic
     on_multi_click:
       - timing:
           - ON for at least 10s
@@ -173,7 +176,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: use_wake_word
+                switch.is_on: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -182,7 +185,7 @@ voice_assistant:
   on_client_connected: 
     - if:
         condition:
-          switch.is_on: use_wake_word
+          switch.is_on: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -253,8 +256,8 @@ script:
 
 switch:
   - platform: template
-    name: Use wake word
-    id: use_wake_word
+    name: Mute
+    id: mute
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     entity_category: config


### PR DESCRIPTION
With the removal of the "Push to talk" functionality on the Boxes, the switch. "Use Wake Word" makes little sense,
So I am renaming it to "Mute" 