### PR TITLE
Inverse the Mute Switch Behavior

### DIFF
--- a/voice-assistant/esp32-s3-box-3.yaml
+++ b/voice-assistant/esp32-s3-box-3.yaml
@@ -183,7 +183,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: mute
+                switch.is_off: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -192,7 +192,7 @@ voice_assistant:
   on_client_connected: 
     - if:
         condition:
-          switch.is_on: mute
+          switch.is_off: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -266,9 +266,9 @@ switch:
     name: Mute
     id: mute
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
-    on_turn_on:
+    on_turn_off:
       - if:
           condition:
             lambda: return !id(init_in_progress);
@@ -282,7 +282,7 @@ switch:
                 then:
                   - voice_assistant.start_continuous
             - script.execute: draw_display
-    on_turn_off:
+    on_turn_on:
       - if:
           condition:
             lambda: return !id(init_in_progress);

--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -231,7 +231,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: mute
+                switch.is_off: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -240,7 +240,7 @@ voice_assistant:
   on_client_connected:
     - if:
         condition:
-          switch.is_on: mute
+          switch.is_off: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -315,9 +315,9 @@ switch:
     name: Mute
     id: mute
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
-    on_turn_on:
+    on_turn_off:
       - if:
           condition:
             lambda: return !id(init_in_progress);
@@ -331,7 +331,7 @@ switch:
                 then:
                   - voice_assistant.start_continuous
             - script.execute: draw_display
-    on_turn_off:
+    on_turn_on:
       - if:
           condition:
             lambda: return !id(init_in_progress);

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -176,7 +176,7 @@ voice_assistant:
           - delay: 1s
           - if:
               condition:
-                switch.is_on: mute
+                switch.is_off: mute
               then:
                 - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
               else:
@@ -185,7 +185,7 @@ voice_assistant:
   on_client_connected: 
     - if:
         condition:
-          switch.is_on: mute
+          switch.is_off: mute
         then:
           - wait_until:
               not: ble.enabled
@@ -259,9 +259,9 @@ switch:
     name: Mute
     id: mute
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
-    on_turn_on:
+    on_turn_off:
       - if:
           condition:
             lambda: return !id(init_in_progress);
@@ -275,7 +275,7 @@ switch:
                 then:
                   - voice_assistant.start_continuous
             - script.execute: draw_display
-    on_turn_off:
+    on_turn_on:
       - if:
           condition:
             lambda: return !id(init_in_progress);


### PR DESCRIPTION
I made a mistake on https://github.com/esphome/firmware/pull/122
I renamed the switch from Use Wake Word to Mute but forgot to invert it.

The behavior today is very confusing has you need to `turn_off` Mute to Mute the device.

Sorry about the confusion, this PR solves this.