### PR TITLE
Add Bluetooth Proxy board definitions for wESP32 modules

### DIFF
--- a/bluetooth-proxy/silicognition-wesp32-lan8270.yaml
+++ b/bluetooth-proxy/silicognition-wesp32-lan8270.yaml
@@ -1,0 +1,46 @@
+substitutions:
+  name: wesp32-bluetooth-proxy
+  friendly_name: Bluetooth Proxy
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  name_add_mac_suffix: true
+  project:
+    name: esphome.bluetooth-proxy
+    version: "1.0"
+
+esp32:
+  board: wesp32
+  framework:
+    type: esp-idf
+
+# Revisions 1-6 of the board use the SMSC LAN8720
+# https://wesp32.com/files/wESP32-Product-Brief.pdf
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO16
+  mdio_pin: GPIO17
+  clk_mode: GPIO0_IN
+  phy_addr: 0
+
+api:
+logger:
+ota:
+
+dashboard_import:
+  package_import_url: github://esphome/firmware/bluetooth-proxy/silicognition-wesp32-lan8720.yaml@main
+
+esp32_ble_tracker:
+  scan_parameters:
+    interval: 1100ms
+    window: 1100ms
+    active: true
+
+bluetooth_proxy:
+  active: true
+
+button:
+  - platform: safe_mode
+    name: Safe Mode Boot
+    entity_category: diagnostic

--- a/bluetooth-proxy/silicognition-wesp32-rtl8201.yaml
+++ b/bluetooth-proxy/silicognition-wesp32-rtl8201.yaml
@@ -1,0 +1,46 @@
+substitutions:
+  name: wesp32-bluetooth-proxy
+  friendly_name: Bluetooth Proxy
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  name_add_mac_suffix: true
+  project:
+    name: esphome.bluetooth-proxy
+    version: "1.0"
+
+esp32:
+  board: wesp32
+  framework:
+    type: esp-idf
+
+# Revisions 7 and above of the board use the Realtek RTL8201
+# https://wesp32.com/files/wESP32-Product-Brief.pdf
+ethernet:
+  type: RTL8201
+  mdc_pin: GPIO16
+  mdio_pin: GPIO17
+  clk_mode: GPIO0_IN
+  phy_addr: 0
+
+api:
+logger:
+ota:
+
+dashboard_import:
+  package_import_url: github://esphome/firmware/bluetooth-proxy/silicognition-wesp32-rtl8201.yaml@main
+
+esp32_ble_tracker:
+  scan_parameters:
+    interval: 1100ms
+    window: 1100ms
+    active: true
+
+bluetooth_proxy:
+  active: true
+
+button:
+  - platform: safe_mode
+    name: Safe Mode Boot
+    entity_category: diagnostic


### PR DESCRIPTION
The [Silicognition wESP32 boards](https://wesp32.com) are ESP32 modules that have onboard ethernet supporting Power-over-Ethernet (PoE).

There are two hardware variants:
- Board revisions 1 to 6 use an SMSC LAN8270 ethernet PHY
- Board revisions 7 and newer use a Realtek RTL8201 ethernet PHY

Both hardware variants use the same GPIO pinout, as described in the [wESP32 Product Brief](https://wesp32.com/files/wESP32-Product-Brief.pdf).

Given that these boards are similar to the [Olimex ESP32 PoE ISO boards](https://github.com/esphome/firmware/blob/main/bluetooth-proxy/olimex-esp32-poe-iso.yaml), I've used that file as the foundation for these wESP32 board files.

I've been able to successfully build both variants, and I've successfully deployed a Bluetooth Proxy on one of the LAN8270 wESP32 boards.