### PR TITLE
Update name of ESP Web Tools firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         include:
           - project: esp-web-tools
-            name: ESP Web Tools
+            name: ESP Web Tools Example
           - project: esphome-web
             name: ESPHome Web
     steps:


### PR DESCRIPTION
Change the ESP Web Tools manifest name to "ESP Web Tools Example" as you are not installing "ESP Web Tools" but an example firmware.

Noticed that there is one downside to setting the name in general. The name of the firmware needs to match the name returned from Improv to offer upgrades to the user. However, ESPHome always returns "ESPHome". But that's for another PR.