### PR TITLE
Text on S3 Boxes

### DIFF
--- a/voice-assistant/esp32-s3-box-3.yaml
+++ b/voice-assistant/esp32-s3-box-3.yaml
@@ -27,7 +27,6 @@ substitutions:
   # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
   allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
 
-
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
@@ -378,7 +377,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -386,7 +385,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -455,7 +453,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
@@ -467,7 +465,7 @@ display:
             it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
             it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
-          }      
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/voice-assistant/esp32-s3-box-3.yaml
+++ b/voice-assistant/esp32-s3-box-3.yaml
@@ -24,6 +24,10 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
+
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
@@ -163,10 +167,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -263,6 +282,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -344,6 +370,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -386,10 +451,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }      
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -23,6 +23,9 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
@@ -210,10 +213,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -310,6 +328,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -391,6 +416,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -431,10 +495,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/voice-assistant/esp32-s3-box-lite.yaml
+++ b/voice-assistant/esp32-s3-box-lite.yaml
@@ -424,7 +424,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -432,7 +432,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -499,7 +498,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -24,6 +24,9 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
@@ -156,10 +159,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -256,6 +274,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -337,6 +362,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -377,10 +441,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/voice-assistant/esp32-s3-box.yaml
+++ b/voice-assistant/esp32-s3-box.yaml
@@ -370,7 +370,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -378,7 +378,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -445,7 +444,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));

--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -24,6 +24,9 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
   micro_wake_word_model: okay_nabu
 
 esphome:
@@ -170,10 +173,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -302,6 +320,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -428,6 +453,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -470,10 +534,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -461,7 +461,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -469,7 +469,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -538,7 +537,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));

--- a/wake-word-voice-assistant/esp32-s3-box-lite.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-lite.yaml
@@ -508,7 +508,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -516,7 +516,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -583,7 +582,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));

--- a/wake-word-voice-assistant/esp32-s3-box-lite.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-lite.yaml
@@ -23,6 +23,9 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
   micro_wake_word_model: okay_nabu
 
 esphome:
@@ -217,10 +220,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -349,6 +367,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -475,6 +500,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -515,10 +579,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/wake-word-voice-assistant/esp32-s3-box.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box.yaml
@@ -24,6 +24,9 @@ substitutions:
   voice_assist_error_phase_id: "11"
   voice_assist_muted_phase_id: "12"
 
+  # These unqiue characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
+  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষস়ািু্చయలిెొ్ംഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹാിീുൂെേൈ്ൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
+
   micro_wake_word_model: okay_nabu
 
 esphome:
@@ -163,10 +166,25 @@ voice_assistant:
   vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
+    - text_sensor.template.publish:
+        id: text_request
+        state: "..."
+    - text_sensor.template.publish:
+        id: text_response
+        state: "..."
     - script.execute: draw_display
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: draw_display
+  on_stt_end:
+    - text_sensor.template.publish:
+        id: text_request
+        state: !lambda return x;
+    - script.execute: draw_display
+  on_tts_start:
+    - text_sensor.template.publish:
+        id: text_response
+        state: !lambda return x;
   on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
@@ -295,6 +313,13 @@ script:
 
 switch:
   - platform: template
+    name: Display conversation
+    id: display_conversation
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+
+  - platform: template
     name: Mute
     id: mute
     optimistic: true
@@ -421,6 +446,45 @@ image:
     type: RGB24
     use_transparency: true
 
+font:
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+      italic: true
+    glyphs: ${allowed_characters}
+    id: font_request
+    size: 15  
+  - file:
+      type: gfonts
+      family: Figtree
+      weight: 300
+    glyphs: ${allowed_characters}
+    id: font_response
+    size: 15
+
+
+text_sensor:
+  - id: text_request
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_request).state.length()>32) {
+          std::string name = id(text_request).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_request).state = (truncated+"...").c_str();
+        }
+
+  - id: text_response
+    platform: template
+    on_value:
+      lambda: |-
+        if(id(text_response).state.length()>32) {
+          std::string name = id(text_response).state.c_str();
+          std::string truncated = esphome::str_truncate(name.c_str(),31);
+          id(text_response).state = (truncated+"...").c_str();
+        }
+
 color:
   - id: idle_color
     hex: ${idle_illustration_background_color}
@@ -461,10 +525,23 @@ display:
         lambda: |-
           it.fill(id(thinking_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_thinking), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+          } 
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));
           it.image((it.get_width() / 2), (it.get_height() / 2), id(casita_replying), ImageAlign::CENTER);
+          if (id(display_conversation).state) {
+            it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
+            it.filled_rectangle(20 , 190 , 280 , 30 , Color::WHITE );
+            it.rectangle(20 , 190 , 280 , 30 , Color::BLACK );
+            it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
+            it.printf(30, 195, id(font_response), Color::BLACK, "%s", id(text_response).state.c_str());
+          }
       - id: error_page
         lambda: |-
           it.fill(id(error_color));

--- a/wake-word-voice-assistant/esp32-s3-box.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box.yaml
@@ -454,7 +454,7 @@ font:
       italic: true
     glyphs: ${allowed_characters}
     id: font_request
-    size: 15  
+    size: 15
   - file:
       type: gfonts
       family: Figtree
@@ -462,7 +462,6 @@ font:
     glyphs: ${allowed_characters}
     id: font_response
     size: 15
-
 
 text_sensor:
   - id: text_request
@@ -529,7 +528,7 @@ display:
             it.filled_rectangle(20 , 20 , 280 , 30 , Color::WHITE );
             it.rectangle(20 , 20 , 280 , 30 , Color::BLACK );
             it.printf(30, 25, id(font_request), Color::BLACK, "%s", id(text_request).state.c_str());
-          } 
+          }
       - id: replying_page
         lambda: |-
           it.fill(id(replying_color));


### PR DESCRIPTION
The idea is coming from the Voice Assistant Contest.
Credit to [user Lajos and his entry](https://community.home-assistant.io/t/a-jrpg-style-conversation-with-the-voice-assistant-on-the-s3-box-3/697172). 

## Features added
**Spoken text is displayed on the box during the thinking phase**
![IMG_2577](https://github.com/esphome/firmware/assets/5878296/d77ee940-4ea2-4ccb-b188-aedf62efeae0)

**Response text is displayed on the box during the replying phase**
![IMG_2578](https://github.com/esphome/firmware/assets/5878296/3a6b6e15-fcd8-4912-8d6c-aaa94be70c6a)

This behavior is user-configurable via a switch called `Display conversation` on Home Assistant.
![CleanShot 2024-03-14 at 17 33 47](https://github.com/esphome/firmware/assets/5878296/a81c149c-e224-4c4d-a2cf-a9dfd387133e)

The value of the switch is restored, but `ON` by default if no value is found (It will be `ON` when updating for the first time)

## Specific changes of the firmware.

### Allowed characters 
In ESPHome, we need to load what character we are planning to display.
Because the firmware is supposed to be used by all our supported languages, I searched for a proxy that would be a good approximation of every character that we could display.
I ended up extracting all unique characters used in our test file on the [intent repository of Home Assistant](https://github.com/home-assistant/intents) 

This is this part of the firmware:
```yaml
  # These unique characters have been extracted from every test file of every language available on https://github.com/home-assistant/intents (14 March 2024)
  allowed_characters: " !#%'()+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWYZ[]_abcdefghijklmnopqrstuvwxyz{|}°²³µ¿ÁÂÄÅÉÖÚßàáâãäåæçèéêëìíîðñòóôõöøùúûüýþāăąćčďĐđēėęěğĮįıļľŁłńňőřśšťũūůűųźŻżŽžơưșțΆΈΌΐΑΒΓΔΕΖΗΘΚΜΝΠΡΣΤΥΦάέήίαβγδεζηθικλμνξοπρςστυφχψωϊόύώАБВГДЕЖЗИКЛМНОПРСТУХЦЧШЪЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяёђєіїјљњћאבגדהוזחטיכלםמןנסעפץצקרשת،ءآأإئابةتجحخدذرزسشصضطظعغفقكلمنهوىيٹپچڈکگںھہیےংকচতধনফবযরলশষসచయలഅആഇഈഉഎഓകഗങചജഞടഡണതദധനപഫബഭമയരറലളവശസഹൺൻർൽൾაბგდევზთილმნოპრსტუფქყშჩცძჭხạảấầẩậắặẹẽếềểệỉịọỏốồổỗộớờởợụủứừửữựỳ—、一上不个中为主乾了些亮人任低佔何作供依侧係個側偵充光入全关冇冷几切到制前動區卧厅厨及口另右吊后吗启吸呀咗哪唔問啟嗎嘅嘛器圍在场執場外多大始安定客室家密寵对將小少左已帘常幫幾库度庫廊廚廳开式後恆感態成我戲戶户房所扇手打执把拔换掉控插摄整斯新明是景暗更最會有未本模機檯櫃欄次正氏水沒没洗活派温測源溫漏潮激濕灯為無煙照熱燈燥物狀玄现現瓦用發的盞目着睡私空窗立笛管節簾籬紅線红罐置聚聲脚腦腳臥色节著行衣解設調請謝警设调走路車车运連遊運過道邊部都量鎖锁門閂閉開關门闭除隱離電震霧面音頂題顏颜風风食餅餵가간감갔강개거게겨결경고공과관그금급기길깥꺼껐꼽나난내네놀누는능니다닫담대더데도동됐되된됨둡드든등디때떤뜨라래러렇렌려로료른를리림링마많명몇모무문물뭐바밝방배변보부불블빨뽑사산상색서설성세센션소쇼수스습시신실싱아안않알았애야어얼업없었에여연열옆오온완외왼요운움워원위으은을음의이인일임입있작잠장재전절정제져조족종주줄중줘지직진짐쪽차창천최추출충치침커컴켜켰쿠크키탁탄태탬터텔통트튼티파팬퍼폰표퓨플핑한함해했행혀현화활후휴힘，？"
```

Because this solution is not perfect, this list is loaded as a `substitution` so that a user can still add a few missed characters in the list.

### 2-stage thinking phase.
Interestingly enough, we are starting our thinking phase at the end of the VAD stage, in the middle of the STT phase.
This is because we want to take into account the time it takes for the STT engine to fully decode the spoken command.

This means that when we start our thinking phase, the spoken text is not known, the silence has just been detected, and the processing of the last chunk of audio is still ongoing.

At first, I thought that this would be an issue, but I like it even better now.
- At the end of the VAD stage, the thinking phase is displayed. the spoken text is not known so 3 dots `...` are displayed instead. (Basically meaning: " I am still trying to figure out what you told me")
- Once the STT phase is over, the screen is refreshed with the spoken text (Basically meaning: "Ok now I understand what you told me... I am still figuring out what to do, and how to reply to you")

It is visible when the STT engine is slow.
![CleanShot 2024-03-14 at 17 31 22](https://github.com/esphome/firmware/assets/5878296/3349eb91-7bdf-4c8b-936d-813b82bee450)

We do not have this problem for the response, as the thinking phase extends until the streaming of the audio.