### PR TITLE
Timers on M5STACK ATOM ECHO

### DIFF
--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -118,6 +118,36 @@ voice_assistant:
         then:
           - voice_assistant.stop:
           - light.turn_off: led
+  on_timer_finished:
+    - voice_assistant.stop:
+    - switch.turn_on: timer_ringing
+    - wait_until:
+        not:
+          microphone.is_capturing:
+    - light.turn_on:
+        id: led
+        red: 0%
+        green: 100%
+        blue: 0%
+        brightness: 100%
+        effect: "Fast Pulse"
+    - while:
+        condition:
+          switch.is_on: timer_ringing
+        then:
+          - lambda: id(echo_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
+          - delay: 1s
+    - wait_until:
+        not:
+          speaker.is_playing:
+    - light.turn_off: led
+    - switch.turn_off: timer_ringing
+    - if:
+        condition:
+          switch.is_on: use_wake_word
+        then:
+          - voice_assistant.start_continuous:
+          - script.execute: reset_led
 
 binary_sensor:
   - platform: gpio
@@ -130,26 +160,32 @@ binary_sensor:
     id: echo_button
     on_multi_click:
       - timing:
-          - ON for at least 250ms
+          - ON for at least 50ms
           - OFF for at least 50ms
         then:
           - if:
               condition:
-                switch.is_off: use_wake_word
+                switch.is_on: timer_ringing
               then:
-                - if:
-                    condition: voice_assistant.is_running
-                    then:
-                      - voice_assistant.stop:
-                      - script.execute: reset_led
-                    else:
-                      - voice_assistant.start:
+                - switch.turn_off: timer_ringing
               else:
-                - voice_assistant.stop
-                - delay: 1s
-                - script.execute: reset_led
-                - script.wait: reset_led
-                - voice_assistant.start_continuous:
+                - if:
+                    condition:
+                      switch.is_off: use_wake_word
+                    then:
+                      - if:
+                          condition: voice_assistant.is_running
+                          then:
+                            - voice_assistant.stop:
+                            - script.execute: reset_led
+                          else:
+                            - voice_assistant.start:
+                    else:
+                      - voice_assistant.stop
+                      - delay: 1s
+                      - script.execute: reset_led
+                      - script.wait: reset_led
+                      - voice_assistant.start_continuous:
       - timing:
           - ON for at least 10s
         then:
@@ -229,11 +265,27 @@ switch:
       - script.execute: reset_led
     on_turn_off:
       - script.execute: reset_led
+  - platform: template
+    id: timer_ringing
+    optimistic: true
+    internal: true
+    restore_mode: ALWAYS_OFF
+    on_turn_on:
+      - delay: 15min
+      - switch.turn_off: timer_ringing
 
 external_components:
   - source: github://pr#5230
     components:
       - esp_adf
     refresh: 0s
+  - source: github://jesserockz/esphome-components
+    components: [file]
+    refresh: 0s
 
 esp_adf:
+
+file:
+  - id: timer_finished_wave_file
+    # path: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav TO BE FIXED ONCE `file` SUPPORTS REMOTE PATH
+    path: ../voice-assistant/sounds/timer_finished.wav

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -287,5 +287,4 @@ esp_adf:
 
 file:
   - id: timer_finished_wave_file
-    # path: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav TO BE FIXED ONCE `file` SUPPORTS REMOTE PATH
-    path: ../voice-assistant/sounds/timer_finished.wav
+    file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav


### PR DESCRIPTION
## FONCTIONALITIES

Timers on them5Stack Atom Echos

### Timer end behavior
When a timer ends, two things happen
- The LED flashes green
- A sound plays until the button is pressed

**Q&A**
- Can a user change the beep sound?
  - Not in this version, I needed to know the length of the .wav file to loop it. If I can find a way to circumvent that, I may allow users to change sounds.
- If a user ignores the end of the timer, will the box ring forever?
  - No, it will ring for 15 minutes then stop. We built that guardrail in the firmware.

## TODO LIST FOR THIS PR
- [x] @jesserockz : The `file` component used does not support remote paths. For now, this PR references local paths for the sound file but this will cause issues when adopting and customizing the firmware
```yaml
file:
  - id: timer_finished_wave_file
    #path: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav TO BE FIXED ONCE `file` SUPPORTS REMOTE PATH
    path: ..//voice-assistant/sounds/timer_finished.wav
```
