### PR TITLE
Fix Mute State during start-up on the boxes

### DIFF
--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -533,35 +533,35 @@ select:
     initial_option: On device
     on_value:
       - if:
-        condition:
-          lambda: return !id(init_in_progress);
-        then:
-          - wait_until:
-              lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
-          - if:
-              condition:
-                lambda: return x == "In Home Assistant";
-              then:
-                - micro_wake_word.stop
-                - delay: 500ms
-                - if:
-                    condition:
-                      switch.is_off: mute
-                    then:
-                      - lambda: id(va).set_use_wake_word(true);
-                      - voice_assistant.start_continuous:
-          - if:
-              condition:
-                lambda: return x == "On device";
-              then:
-                - lambda: id(va).set_use_wake_word(false);
-                - voice_assistant.stop
-                - delay: 500ms
-                - if:
-                    condition:
-                      switch.is_off: mute
-                    then:
-                      - micro_wake_word.start
+          condition:
+            lambda: return !id(init_in_progress);
+          then:
+            - wait_until:
+                lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
+            - if:
+                condition:
+                  lambda: return x == "In Home Assistant";
+                then:
+                  - micro_wake_word.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - lambda: id(va).set_use_wake_word(true);
+                        - voice_assistant.start_continuous:
+            - if:
+                condition:
+                  lambda: return x == "On device";
+                then:
+                  - lambda: id(va).set_use_wake_word(false);
+                  - voice_assistant.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - micro_wake_word.start
 
 globals:
   - id: init_in_progress

--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -532,28 +532,36 @@ select:
       - On device
     initial_option: On device
     on_value:
-      - wait_until:
-          lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
-      - if:
+       - if:
           condition:
-            lambda: return x == "In Home Assistant";
+            lambda: return !id(init_in_progress);
           then:
-            - micro_wake_word.stop
-            - delay: 500ms
+            - wait_until:
+                lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
             - if:
                 condition:
-                  switch.is_off: mute
+                  lambda: return x == "In Home Assistant";
                 then:
-                  - lambda: id(va).set_use_wake_word(true);
-                  - voice_assistant.start_continuous:
-      - if:
-          condition:
-            lambda: return x == "On device";
-          then:
-            - lambda: id(va).set_use_wake_word(false);
-            - voice_assistant.stop
-            - delay: 500ms
-            - micro_wake_word.start
+                  - micro_wake_word.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - lambda: id(va).set_use_wake_word(true);
+                        - voice_assistant.start_continuous:
+            - if:
+                condition:
+                  lambda: return x == "On device";
+                then:
+                  - lambda: id(va).set_use_wake_word(false);
+                  - voice_assistant.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - micro_wake_word.start
 
 globals:
   - id: init_in_progress

--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -532,36 +532,36 @@ select:
       - On device
     initial_option: On device
     on_value:
-       - if:
-          condition:
-            lambda: return !id(init_in_progress);
-          then:
-            - wait_until:
-                lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
-            - if:
-                condition:
-                  lambda: return x == "In Home Assistant";
-                then:
-                  - micro_wake_word.stop
-                  - delay: 500ms
-                  - if:
-                      condition:
-                        switch.is_off: mute
-                      then:
-                        - lambda: id(va).set_use_wake_word(true);
-                        - voice_assistant.start_continuous:
-            - if:
-                condition:
-                  lambda: return x == "On device";
-                then:
-                  - lambda: id(va).set_use_wake_word(false);
-                  - voice_assistant.stop
-                  - delay: 500ms
-                  - if:
-                      condition:
-                        switch.is_off: mute
-                      then:
-                        - micro_wake_word.start
+      - if:
+        condition:
+          lambda: return !id(init_in_progress);
+        then:
+          - wait_until:
+              lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
+          - if:
+              condition:
+                lambda: return x == "In Home Assistant";
+              then:
+                - micro_wake_word.stop
+                - delay: 500ms
+                - if:
+                    condition:
+                      switch.is_off: mute
+                    then:
+                      - lambda: id(va).set_use_wake_word(true);
+                      - voice_assistant.start_continuous:
+          - if:
+              condition:
+                lambda: return x == "On device";
+              then:
+                - lambda: id(va).set_use_wake_word(false);
+                - voice_assistant.stop
+                - delay: 500ms
+                - if:
+                    condition:
+                      switch.is_off: mute
+                    then:
+                      - micro_wake_word.start
 
 globals:
   - id: init_in_progress

--- a/wake-word-voice-assistant/esp32-s3-box-lite.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-lite.yaml
@@ -584,28 +584,36 @@ select:
       - On device
     initial_option: On device
     on_value:
-      - wait_until:
-          lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
       - if:
           condition:
-            lambda: return x == "In Home Assistant";
+            lambda: return !id(init_in_progress);
           then:
-            - micro_wake_word.stop
-            - delay: 500ms
+            - wait_until:
+                lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
             - if:
                 condition:
-                  switch.is_off: mute
+                  lambda: return x == "In Home Assistant";
                 then:
-                  - lambda: id(va).set_use_wake_word(true);
-                  - voice_assistant.start_continuous:
-      - if:
-          condition:
-            lambda: return x == "On device";
-          then:
-            - lambda: id(va).set_use_wake_word(false);
-            - voice_assistant.stop
-            - delay: 500ms
-            - micro_wake_word.start
+                  - micro_wake_word.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - lambda: id(va).set_use_wake_word(true);
+                        - voice_assistant.start_continuous:
+            - if:
+                condition:
+                  lambda: return x == "On device";
+                then:
+                  - lambda: id(va).set_use_wake_word(false);
+                  - voice_assistant.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - micro_wake_word.start
 
 globals:
   - id: init_in_progress

--- a/wake-word-voice-assistant/esp32-s3-box.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box.yaml
@@ -524,28 +524,36 @@ select:
       - On device
     initial_option: On device
     on_value:
-      - wait_until:
-          lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
       - if:
           condition:
-            lambda: return x == "In Home Assistant";
+            lambda: return !id(init_in_progress);
           then:
-            - micro_wake_word.stop
-            - delay: 500ms
+            - wait_until:
+                lambda: return id(voice_assistant_phase) == ${voice_assist_muted_phase_id} || id(voice_assistant_phase) == ${voice_assist_idle_phase_id};
             - if:
                 condition:
-                  switch.is_off: mute
+                  lambda: return x == "In Home Assistant";
                 then:
-                  - lambda: id(va).set_use_wake_word(true);
-                  - voice_assistant.start_continuous:
-      - if:
-          condition:
-            lambda: return x == "On device";
-          then:
-            - lambda: id(va).set_use_wake_word(false);
-            - voice_assistant.stop
-            - delay: 500ms
-            - micro_wake_word.start
+                  - micro_wake_word.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - lambda: id(va).set_use_wake_word(true);
+                        - voice_assistant.start_continuous:
+            - if:
+                condition:
+                  lambda: return x == "On device";
+                then:
+                  - lambda: id(va).set_use_wake_word(false);
+                  - voice_assistant.stop
+                  - delay: 500ms
+                  - if:
+                      condition:
+                        switch.is_off: mute
+                      then:
+                        - micro_wake_word.start
 
 globals:
   - id: init_in_progress


### PR DESCRIPTION
The `micro_wake_word.start` that was under `on_value` of the select `wake_word_engine_location` was triggered during start-up even if the box was supposed to be muted.

This led to a box in a weird state: 
- Back screen as if it was muted
- Still able to wake it up

I made that `on_value` more robust.
I added a condition on `init_in_progress` (because nothing should happen in that stage anyway)
More importantly, I added a `mute` condition when the value changed to `On Device` to avoid starting micro_wake_word when the device is muted.