### PR TITLE
Disable openWakeWord when using microWakeWord

### DIFF
--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -182,7 +182,6 @@ voice_assistant:
   id: va
   microphone: box_mic
   speaker: box_speaker
-  use_wake_word: true
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0
@@ -445,6 +444,7 @@ script:
                 condition:
                   lambda: return id(wake_word_engine_location).state == "On device";
                 then:
+                  - lambda: id(va).set_use_wake_word(false);
                   - micro_wake_word.start
             - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
           else:
@@ -501,6 +501,7 @@ switch:
                       condition:
                         lambda: return id(wake_word_engine_location).state == "On device";
                       then:
+                        - lambda: id(va).set_use_wake_word(false);
                         - micro_wake_word.start
             - script.execute: draw_display
     on_turn_on:

--- a/wake-word-voice-assistant/esp32-s3-box-lite.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-lite.yaml
@@ -234,7 +234,6 @@ voice_assistant:
   id: va
   microphone: box_mic
   speaker: box_speaker
-  use_wake_word: true
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0
@@ -496,6 +495,7 @@ script:
                 condition:
                   lambda: return id(wake_word_engine_location).state == "On device";
                 then:
+                  - lambda: id(va).set_use_wake_word(false);
                   - micro_wake_word.start
             - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
           else:
@@ -552,6 +552,7 @@ switch:
                       condition:
                         lambda: return id(wake_word_engine_location).state == "On device";
                       then:
+                        - lambda: id(va).set_use_wake_word(false);
                         - micro_wake_word.start
             - script.execute: draw_display
     on_turn_on:

--- a/wake-word-voice-assistant/esp32-s3-box.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box.yaml
@@ -175,7 +175,6 @@ voice_assistant:
   id: va
   microphone: box_mic
   speaker: box_speaker
-  use_wake_word: true
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0
@@ -437,6 +436,7 @@ script:
                 condition:
                   lambda: return id(wake_word_engine_location).state == "On device";
                 then:
+                  - lambda: id(va).set_use_wake_word(false);
                   - micro_wake_word.start
             - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
           else:
@@ -493,6 +493,7 @@ switch:
                       condition:
                         lambda: return id(wake_word_engine_location).state == "On device";
                       then:
+                        - lambda: id(va).set_use_wake_word(false);
                         - micro_wake_word.start
             - script.execute: draw_display
     on_turn_on:


### PR DESCRIPTION
Took me a while to figure out why the on-device wake word was no longer working after a restart until I muted & unmuted.  My understanding is that the `use_wake_word` config is for detecting audio with the esp-adf libraries & VAD then sending the audio data through the pipeline to be processed by openWakeWord.  Unfortunately this conflicts with microWakeWord processed locally.

Seems to have been surfaced after the otherwise helpful https://github.com/esphome/firmware/pull/214.  Before, the `on_value` automation in `wake_word_engine_location` would run `set_use_wake_word(false)` at boot when it's configured for On device detection.  Now with the `init_in_progress` check, that doesn't run and is initially left on.

Here's a potential fix that also removes the `use_wake_word` config, defaulting to false to match the "On device" initial_option.

May relate to https://github.com/esphome/firmware/issues/219 as well.