### PR TITLE
[WIP] Option to reply on different device for Atom M5

### DIFF
--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -60,6 +60,14 @@ speaker:
     dac_type: external
     mode: mono
 
+text_sensor:
+  - platform: template
+    name: "media player"
+    id: "media_player"
+    lambda: |-
+      return {"media_player.study_speaker"};
+    update_interval: 60s
+
 voice_assistant:
   id: va
   microphone: echo_microphone
@@ -90,6 +98,14 @@ voice_assistant:
         green: 0%
         brightness: 100%
         effect: none
+  on_tts_end:
+     - homeassistant.service:
+         service: media_player.play_media
+         data:
+           entity_id: !lambda 'return media_player.state;' # <- change this
+           media_content_id: !lambda 'return x;'
+           media_content_type: music
+           announce: "false"
   on_end:
     - delay: 100ms
     - wait_until:
@@ -137,7 +153,22 @@ voice_assistant:
         condition:
           switch.is_on: timer_ringing
         then:
-          - lambda: id(echo_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
+          - if:
+              condition:
+                not:
+                  media_player.state:
+                  id: my_text_sensor
+                  state: ''
+              then:
+                - homeassistant.service:
+                  service: media_player.play_media
+                  data:
+                    entity_id: media_player.study_speaker # <- change this
+                    media_content_id: !lambda 'return x;'
+                    media_content_type: music
+                    announce: "false"
+              else:
+                - lambda: id(echo_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
           - delay: 1s
     - wait_until:
         not:

--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -163,8 +163,8 @@ voice_assistant:
                 - homeassistant.service:
                   service: media_player.play_media
                   data:
-                    entity_id: media_player.study_speaker # <- change this
-                    media_content_id: !lambda 'return x;'
+                    entity_id: !lambda 'return media_player.state;' # <- change this
+                    media_content_id: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav
                     media_content_type: music
                     announce: "false"
               else:


### PR DESCRIPTION
I'm very newbie to editing ESP home firmware

Looking to create an optional dropdown within the HA ui to select a media player. If a media player is selected then the TTS and timers should take place on the media player and not the device

related forum post with 100 upvotes: https://community.home-assistant.io/t/voice-assistant-have-assistant-reply-on-a-different-media-player/625875/6