### PR TITLE
Publish firmware only on release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,10 @@ name: Build
 
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
   pull_request:
-  schedule:
-    - cron: "0 5 * * 1"
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -178,7 +175,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    if: contains(fromJSON('["workflow_dispatch", "push", "schedule"]'), github.event_name) && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'release'
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: consolidate


### PR DESCRIPTION
Because we now have to bump the versions in files, we should release properly with tags/releases.