### PR TITLE
Partial rollback of #223 to fix install error on M5 Stack Atom Echo

### DIFF
--- a/voice-assistant/m5stack-atom-echo.yaml
+++ b/voice-assistant/m5stack-atom-echo.yaml
@@ -22,12 +22,6 @@ ota:
   - platform: http_request
     id: ota_http_request
 
-update:
-  - platform: http_request
-    id: update_http_request
-    name: Firmware
-    source: https://firmware.esphome.io/voice-assistant/m5stack-atom-echo/manifest.json
-
 http_request:
 
 dashboard_import:


### PR DESCRIPTION
Fixes #227

Since #223 / a79c9fa96fe0fdd24c17e7571de3ef37755d54a1 local installation of the firmware on the M5 Stack Atom Echo fails due to image size, see:
 - https://github.com/esphome/firmware/issues/227
 - #234 
 - #240 
 - https://community.home-assistant.io/t/m5-stack-atom-echo-installation/746641/2
 - And possibly https://github.com/esphome/issues/issues/5714

Rolling back to cd57ca6f951d44cc5bf61de124a15b349ef1f9a4 worked for many users as can be seen on [this comment](https://github.com/esphome/firmware/issues/227#issuecomment-2211758801) and below on #227 

This yaml also works for me
```yml
substitutions:
  name: m5stack-atom-echo-b836b0
  friendly_name: M5Stack Atom Echo b836b0
packages:
  m5stack.atom-echo-voice-assistant: github://esphome/firmware/voice-assistant/m5stack-atom-echo.yaml@main
esphome:
  name: ${name}
  name_add_mac_suffix: false
  friendly_name: ${friendly_name}
api:
  encryption:
    key: +yourAPIKEY=


wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

# HarvsG's customisations 2024-07-10, will likely break UI updating in HomeAssistant and 
# can be deleted once https://github.com/esphome/firmware/issues/227 is fixed
update:
  - platform: http_request
    id: !remove update_http_request
```

This narrows the issue down to:
https://github.com/esphome/firmware/blob/fdece7e67fb6fb1485db52070a949251fe798ea1/voice-assistant/m5stack-atom-echo.yaml#L25-L29.

Now since it seems to be an image size issue, I guess it is possible that removing any component may improve things, but it seems sensible to roll back the most recent. 

NB: My tests were done on 2024.6.6
Edit: It may be worth widening the scope of the rollback as https://github.com/esphome/firmware/issues/228 seems related to PR #223 as well.