### PR TITLE
New micro wake word 2 `m5stack-atom-echo.yaml`

### DIFF
--- a/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
@@ -24,6 +24,8 @@ ota:
 wifi:
   ap:
 
+captive_portal:
+
 button:
   - platform: factory_reset
     id: factory_reset_btn

--- a/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
@@ -8,9 +8,6 @@ esphome:
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
   min_version: 2024.7.1
-  project:
-    name: m5stack.atom-echo-wake-word-voice-assistant
-    version: "24.7.29"
 
 esp32:
   board: m5stack-atom
@@ -23,24 +20,9 @@ api:
 ota:
   - platform: esphome
     id: ota_esphome
-  - platform: http_request
-    id: ota_http_request
-
-update:
-  - platform: http_request
-    id: update_http_request
-    name: Firmware
-    source: https://firmware.esphome.io/wake-word-voice-assistant/m5stack-atom-echo/manifest.json
-
-http_request:
-
-dashboard_import:
-  package_import_url: github://esphome/firmware/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml@main
 
 wifi:
   ap:
-
-improv_serial:
 
 button:
   - platform: factory_reset
@@ -125,7 +107,7 @@ voice_assistant:
     - delay: 2s
     - script.execute: reset_led
   on_client_connected:
-    - delay: 2s  # Give the api server time to settle
+      - delay: 2s  # Give the api server time to settle
     - if:
         condition:
           lambda: return id(wake_word_engine_location).state == "On device";

--- a/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.adopted.yaml
@@ -109,7 +109,7 @@ voice_assistant:
     - delay: 2s
     - script.execute: reset_led
   on_client_connected:
-      - delay: 2s  # Give the api server time to settle
+    - delay: 2s  # Give the api server time to settle
     - if:
         condition:
           lambda: return id(wake_word_engine_location).state == "On device";

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  micro_wake_word_model: okay_nabu # hey_jarvis and hey_mycroft are also supported
+  micro_wake_word_model: okay_nabu # alexa, hey_jarvis and hey_mycroft are also supported
 esphome:
   name: ${name}
   name_add_mac_suffix: true

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -37,17 +37,17 @@ dashboard_import:
   package_import_url: github://esphome/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@main
 
 wifi:
-  on_connect:
-    - delay: 5s  # Gives time for improv results to be transmitted
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
+#  on_connect:
+#    - delay: 5s  # Gives time for improv results to be transmitted
+#    - ble.disable:
+#  on_disconnect:
+#    - ble.enable:
   ap:
 
 improv_serial:
 
-esp32_improv:
-  authorizer: none
+#esp32_improv:
+#  authorizer: none
 
 button:
   - platform: factory_reset

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -341,12 +341,12 @@ esp_adf:
 
 file:
   - id: timer_finished_wave_file
-    file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav 
+    file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav
 
 micro_wake_word:
   on_wake_word_detected:
-    - voice_assistant.start: 
+    - voice_assistant.start:
         wake_word: !lambda return wake_word; 
   vad:
-  models: 
-    - model: ${micro_wake_word_model} 
+  models:
+    - model: ${micro_wake_word_model}

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-
+  micro_wake_word_model: okay_nabu # hey_jarvis and hey_mycroft are also supported
 esphome:
   name: ${name}
   name_add_mac_suffix: true
@@ -345,6 +345,4 @@ micro_wake_word:
         wake_word: !lambda return wake_word; 
   vad:
   models:
-    - model: okay_nabu
-#    - model: hey_jarvis
-#    - model: hey_mycroft
+    - model: ${micro_wake_word_model}

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
   micro_wake_word_model: okay_nabu # alexa, hey_jarvis, hey_mycroft are also supported
-  2nd_micro_wake_word_model: #
 esphome:
   name: ${name}
   name_add_mac_suffix: true
@@ -350,6 +349,4 @@ micro_wake_word:
         wake_word: !lambda return wake_word; 
   vad:
   models: 
-    - model: ${micro_wake_word_model}
-    - model: ${2nd_micro_wake_word_model}
-  
+    - model: ${micro_wake_word_model} 

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,1 +1,349 @@
-<<: !include ../voice-assistant/m5stack-atom-echo.yaml
+substitutions:
+  name: m5stack-atom-echo
+  friendly_name: M5Stack Atom Echo
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: true
+  friendly_name: ${friendly_name}
+  min_version: 2024.7.1
+  project:
+    name: m5stack.atom-echo-voice-assistant
+    version: "24.7.4.1"
+
+esp32:
+  board: m5stack-atom
+  framework:
+    type: esp-idf
+
+logger:
+api:
+
+ota:
+  - platform: esphome
+    id: ota_esphome
+  - platform: http_request
+    id: ota_http_request
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://firmware.esphome.io/wake-word-voice-assistant/m5stack-atom-echo/manifest.json
+
+dashboard_import:
+  package_import_url: github://esphome/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@main
+
+wifi:
+  on_connect:
+    - delay: 5s  # Gives time for improv results to be transmitted
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
+  ap:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none
+
+button:
+  - platform: factory_reset
+    id: factory_reset_btn
+    name: Factory reset
+
+i2s_audio:
+  - id: i2s_audio_bus
+    i2s_lrclk_pin: GPIO33
+    i2s_bclk_pin: GPIO19
+
+microphone:
+  - platform: i2s_audio
+    id: echo_microphone
+    i2s_din_pin: GPIO23
+    adc_type: external
+    pdm: true
+
+speaker:
+  - platform: i2s_audio
+    id: echo_speaker
+    i2s_dout_pin: GPIO22 
+    dac_type: external
+    mode: mono
+
+voice_assistant:
+  id: va
+  microphone: echo_microphone
+  speaker: echo_speaker
+  noise_suppression_level: 2
+  auto_gain: 31dBFS
+  volume_multiplier: 2.0
+  vad_threshold: 3
+  on_listening:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Slow Pulse"
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: "Fast Pulse"
+  on_tts_start:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        brightness: 100%
+        effect: none
+  on_end:
+    - delay: 100ms
+    - voice_assistant.stop:
+    - wait_until:
+        not:
+          voice_assistant.is_running:
+    - wait_until:
+        not:
+          switch.is_on: timer_ringing
+    - if:
+        condition:
+          switch.is_on: use_micro_wake_word
+        then:
+          - micro_wake_word.start:
+          - script.execute: reset_led
+        else:
+          - voice_assistant.start_continuous:
+          - script.execute: reset_led
+  on_error:
+    - light.turn_on:
+        id: led
+        red: 100%
+        green: 0%
+        blue: 0%
+        brightness: 100%
+        effect: none
+    - delay: 2s
+    - script.execute: reset_led
+  on_client_connected:
+    - delay: 5s
+    - if:
+        condition:
+          switch.is_on: use_micro_wake_word
+        then:
+          - micro_wake_word.start:
+        else:
+          - voice_assistant.start_continuous:
+          - script.execute: reset_led
+  on_client_disconnected:
+    - voice_assistant.stop:
+    - micro_wake_word.stop:
+  on_timer_finished:
+    - voice_assistant.stop:
+    - micro_wake_word.stop:
+    - switch.turn_on: timer_ringing
+    - wait_until:
+        not:
+          microphone.is_capturing:
+    - light.turn_on:
+        id: led
+        red: 0%
+        green: 100%
+        blue: 0%
+        brightness: 100%
+        effect: "Fast Pulse"
+    - while:
+        condition:
+          switch.is_on: timer_ringing
+        then:
+          - lambda: id(echo_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
+          - delay: 1s
+    - wait_until:
+        not:
+          speaker.is_playing:
+    - light.turn_off: led
+    - switch.turn_off: timer_ringing
+    - if:
+        condition:
+          switch.is_on: use_micro_wake_word 
+        then:
+          - micro_wake_word.start:
+          - script.execute: reset_led
+        else:
+          - voice_assistant.start_continuous:
+          - script.execute: reset_led
+
+binary_sensor:
+  # butto does the following:
+  # short click - stop a timer, if no timer then restart either microwakeword or voice assistant continuous
+  - platform: gpio
+    pin:
+      number: GPIO39
+      inverted: true
+    name: Button
+    disabled_by_default: true
+    entity_category: diagnostic
+    id: echo_button
+    on_multi_click:
+      - timing:
+          - ON for at least 50ms
+          - OFF for at least 50ms
+        then:
+          - if:
+              condition:
+                switch.is_on: timer_ringing
+              then:
+                - switch.turn_off: timer_ringing
+              else:
+                - if:
+                    condition:
+                      switch.is_on: use_micro_wake_word
+                    then:
+                      - voice_assistant.stop
+                      - micro_wake_word.stop:
+                      - delay: 1s
+                      - script.execute: reset_led
+                      - script.wait: reset_led
+                      - micro_wake_word.start:
+                    else:
+                      - if:
+                          condition: voice_assistant.is_running
+                          then:
+                            - voice_assistant.stop:
+                            - script.execute: reset_led
+                      - voice_assistant.start_continuous: 
+      - timing:
+          - ON for at least 10s
+        then:
+          - button.press: factory_reset_btn
+
+light:
+  - platform: esp32_rmt_led_strip
+    id: led
+    name: None
+    disabled_by_default: true
+    entity_category: config
+    pin: GPIO27
+    default_transition_length: 0s
+    chipset: SK6812
+    num_leds: 1
+    rgb_order: grb
+    rmt_channel: 0
+    effects:
+      - pulse:
+          name: "Slow Pulse"
+          transition_length: 250ms
+          update_interval: 250ms
+          min_brightness: 50%
+          max_brightness: 100%
+      - pulse:
+          name: "Fast Pulse"
+          transition_length: 100ms
+          update_interval: 100ms
+          min_brightness: 50%
+          max_brightness: 100%
+
+script:
+  - id: reset_led
+    then:
+      - if:
+          condition:
+            - switch.is_on: use_micro_wake_word
+            - switch.is_on: use_listen_light
+          then:
+            - light.turn_on:
+                id: led
+                red: 100%
+                green: 89%
+                blue: 71%
+                brightness: 60%
+                effect: none
+          else:
+           - if:
+              condition:
+                - switch.is_off: use_micro_wake_word
+                - switch.is_on: use_listen_light
+              then:
+                - light.turn_on:
+                    id: led
+                    red: 0%
+                    green: 100%
+                    blue: 100%
+                    brightness: 60%
+                    effect: none
+              else:
+               - light.turn_off: led
+
+switch:
+  - platform: template
+    name: Use micro wake word
+    id: use_micro_wake_word
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+    on_turn_on:
+      - voice_assistant.stop:
+      - lambda: id(va).set_use_wake_word(false);
+      - delay: 1s
+      - micro_wake_word.start:
+      - script.execute: reset_led
+    on_turn_off:
+      - micro_wake_word.stop:
+      - lambda: id(va).set_use_wake_word(true);
+      - delay: 1s
+      - voice_assistant.start_continuous:
+      - script.execute: reset_led
+  - platform: template
+    name: Use listen light
+    id: use_listen_light
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    entity_category: config
+    on_turn_on:
+      - script.execute: reset_led
+    on_turn_off:
+      - script.execute: reset_led
+  - platform: template
+    id: timer_ringing
+    optimistic: true
+    internal: true
+    restore_mode: ALWAYS_OFF
+    on_turn_on:
+      - delay: 15min
+      - switch.turn_off: timer_ringing
+
+external_components:
+  - source: github://pr#5230
+    components:
+      - esp_adf
+    refresh: 0s
+  - source: github://jesserockz/esphome-components
+    components: [file]
+    refresh: 0s
+  - source:
+      type: git
+      url: https://github.com/kahrendt/esphome
+      ref:  mww-v2-external-library
+    refresh: 0s
+    components: [ micro_wake_word ] 
+
+esp_adf:
+
+file:
+  - id: timer_finished_wave_file
+    file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav 
+
+micro_wake_word:
+  on_wake_word_detected:
+    - voice_assistant.start: 
+        wake_word: !lambda return wake_word; 
+  vad:
+    model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/vad.json
+  models:
+    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/okay_nabu.json
+#    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/hey_jarvis.json
+#    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/hey_mycroft.json

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -259,19 +259,19 @@ script:
                 effect: none
           else:
             - if:
-              condition:
-                - lambda: return id(wake_word_engine_location).state != "On device";
-                - switch.is_on: use_listen_light
-              then:
-                - light.turn_on:
-                    id: led
-                    red: 0%
-                    green: 100%
-                    blue: 100%
-                    brightness: 60%
-                    effect: none
-              else:
-                - light.turn_off: led
+                condition:
+                  - lambda: return id(wake_word_engine_location).state != "On device";
+                  - switch.is_on: use_listen_light
+                then:
+                  - light.turn_on:
+                      id: led
+                      red: 0%
+                      green: 100%
+                      blue: 100%
+                      brightness: 60%
+                      effect: none
+                else:
+                  - light.turn_off: led
 
 switch:
   - platform: template

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -172,8 +172,9 @@ voice_assistant:
           - script.execute: reset_led
 
 binary_sensor:
-  # butto does the following:
-  # short click - stop a timer, if no timer then restart either microwakeword or voice assistant continuous
+  # button does the following:
+  # short click - stop a timer
+  # if no timer then restart either microwakeword or voice assistant continuous
   - platform: gpio
     pin:
       number: GPIO39

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  micro_wake_word_model: okay_nabu # alexa, hey_jarvis, hey_mycroft are also supported
+  micro_wake_word_model: okay_nabu  # alexa, hey_jarvis, hey_mycroft are also supported
 esphome:
   name: ${name}
   name_add_mac_suffix: true
@@ -61,7 +61,7 @@ microphone:
 speaker:
   - platform: i2s_audio
     id: echo_speaker
-    i2s_dout_pin: GPIO22 
+    i2s_dout_pin: GPIO22
     dac_type: external
     mode: mono
 
@@ -163,7 +163,7 @@ voice_assistant:
     - switch.turn_off: timer_ringing
     - if:
         condition:
-          lambda: return id(wake_word_engine_location).state == "On device"; 
+          lambda: return id(wake_word_engine_location).state == "On device";
         then:
           - micro_wake_word.start:
           - script.execute: reset_led
@@ -210,7 +210,7 @@ binary_sensor:
                           then:
                             - voice_assistant.stop:
                             - script.execute: reset_led
-                      - voice_assistant.start_continuous: 
+                      - voice_assistant.start_continuous:
       - timing:
           - ON for at least 10s
         then:
@@ -258,7 +258,7 @@ script:
                 brightness: 60%
                 effect: none
           else:
-           - if:
+            - if:
               condition:
                 - lambda: return id(wake_word_engine_location).state != "On device";
                 - switch.is_on: use_listen_light
@@ -271,7 +271,7 @@ script:
                     brightness: 60%
                     effect: none
               else:
-               - light.turn_off: led
+                - light.turn_off: led
 
 switch:
   - platform: template
@@ -333,9 +333,9 @@ external_components:
   - source:
       type: git
       url: https://github.com/kahrendt/esphome
-      ref:  mww-v2-external-library
+      ref: mww-v2-external-library
     refresh: 0s
-    components: [ micro_wake_word ] 
+    components: [micro_wake_word]
 
 esp_adf:
 

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -344,8 +344,7 @@ micro_wake_word:
     - voice_assistant.start: 
         wake_word: !lambda return wake_word; 
   vad:
-    model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/vad.json
   models:
-    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/okay_nabu.json
-#    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/hey_jarvis.json
-#    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/hey_mycroft.json
+    - model: okay_nabu
+#    - model: hey_jarvis
+#    - model: hey_mycroft

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -31,6 +31,8 @@ update:
     name: Firmware
     source: https://firmware.esphome.io/wake-word-voice-assistant/m5stack-atom-echo/manifest.json
 
+http_request:
+
 dashboard_import:
   package_import_url: github://esphome/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@main
 

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -106,7 +106,7 @@ voice_assistant:
           switch.is_on: timer_ringing
     - if:
         condition:
-          switch.is_on: use_micro_wake_word
+          lambda: return id(wake_word_engine_location).state == "On device";
         then:
           - micro_wake_word.start:
           - script.execute: reset_led
@@ -127,7 +127,7 @@ voice_assistant:
     - delay: 5s
     - if:
         condition:
-          switch.is_on: use_micro_wake_word
+          lambda: return id(wake_word_engine_location).state == "On device";
         then:
           - micro_wake_word.start:
         else:
@@ -163,7 +163,7 @@ voice_assistant:
     - switch.turn_off: timer_ringing
     - if:
         condition:
-          switch.is_on: use_micro_wake_word 
+          lambda: return id(wake_word_engine_location).state == "On device"; 
         then:
           - micro_wake_word.start:
           - script.execute: reset_led
@@ -196,7 +196,7 @@ binary_sensor:
               else:
                 - if:
                     condition:
-                      switch.is_on: use_micro_wake_word
+                      lambda: return id(wake_word_engine_location).state == "On device";
                     then:
                       - voice_assistant.stop
                       - micro_wake_word.stop:
@@ -247,7 +247,7 @@ script:
     then:
       - if:
           condition:
-            - switch.is_on: use_micro_wake_word
+            - lambda: return id(wake_word_engine_location).state == "On device";
             - switch.is_on: use_listen_light
           then:
             - light.turn_on:
@@ -310,6 +310,35 @@ switch:
     on_turn_on:
       - delay: 15min
       - switch.turn_off: timer_ringing
+
+select:
+  - platform: template
+    entity_category: config
+    name: Wake word engine location
+    id: wake_word_engine_location
+    optimistic: true
+    restore_value: true
+    options:
+      - In Home Assistant
+      - On device
+    initial_option: On device
+    on_value:
+      - if:
+          condition:
+            lambda: return x == "In Home Assistant";
+          then:
+            - micro_wake_word.stop
+            - delay: 500ms
+            - lambda: id(va).set_use_wake_word(true);
+            - voice_assistant.start_continuous:
+      - if:
+          condition:
+            lambda: return x == "On device";
+          then:
+            - lambda: id(va).set_use_wake_word(false);
+            - voice_assistant.stop
+            - delay: 500ms
+            - micro_wake_word.start
 
 external_components:
   - source: github://pr#5230

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -260,7 +260,7 @@ script:
           else:
            - if:
               condition:
-                - lambda: return id(wake_word_engine_location).state == "On device";
+                - lambda: return id(wake_word_engine_location).state != "On device";
                 - switch.is_on: use_listen_light
               then:
                 - light.turn_on:

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,7 +1,11 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  micro_wake_word_model: okay_nabu # alexa, hey_jarvis and hey_mycroft are also supported
+  micro_wake_word_models: 
+    - model: okay_nabu
+#    - model: alexa 
+#    - model: hey_jarvis 
+#    - model: hey_mycroft
 esphome:
   name: ${name}
   name_add_mac_suffix: true
@@ -348,5 +352,4 @@ micro_wake_word:
     - voice_assistant.start: 
         wake_word: !lambda return wake_word; 
   vad:
-  models:
-    - model: ${micro_wake_word_model}
+  models: ${micro_wake_word_models}

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -8,7 +8,7 @@ esphome:
   friendly_name: ${friendly_name}
   min_version: 2024.7.1
   project:
-    name: m5stack.atom-echo-voice-assistant
+    name: m5stack.atom-echo-wake-word-voice-assistant
     version: "24.7.4.1"
 
 esp32:

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -260,7 +260,7 @@ script:
           else:
            - if:
               condition:
-                - switch.is_off: use_micro_wake_word
+                - lambda: return id(wake_word_engine_location).state == "On device";
                 - switch.is_on: use_listen_light
               then:
                 - light.turn_on:
@@ -274,24 +274,6 @@ script:
                - light.turn_off: led
 
 switch:
-  - platform: template
-    name: Use micro wake word
-    id: use_micro_wake_word
-    optimistic: true
-    restore_mode: RESTORE_DEFAULT_ON
-    entity_category: config
-    on_turn_on:
-      - voice_assistant.stop:
-      - lambda: id(va).set_use_wake_word(false);
-      - delay: 1s
-      - micro_wake_word.start:
-      - script.execute: reset_led
-    on_turn_off:
-      - micro_wake_word.stop:
-      - lambda: id(va).set_use_wake_word(true);
-      - delay: 1s
-      - voice_assistant.start_continuous:
-      - script.execute: reset_led
   - platform: template
     name: Use listen light
     id: use_listen_light

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -42,6 +42,8 @@ wifi:
 
 improv_serial:
 
+captive_portal:
+
 button:
   - platform: factory_reset
     id: factory_reset_btn

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -1,11 +1,8 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  micro_wake_word_models: 
-    - model: okay_nabu
-#    - model: alexa 
-#    - model: hey_jarvis 
-#    - model: hey_mycroft
+  micro_wake_word_model: okay_nabu # alexa, hey_jarvis, hey_mycroft are also supported
+  2nd_micro_wake_word_model: #
 esphome:
   name: ${name}
   name_add_mac_suffix: true
@@ -352,4 +349,7 @@ micro_wake_word:
     - voice_assistant.start: 
         wake_word: !lambda return wake_word; 
   vad:
-  models: ${micro_wake_word_models}
+  models: 
+    - model: ${micro_wake_word_model}
+    - model: ${2nd_micro_wake_word_model}
+  

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -37,17 +37,9 @@ dashboard_import:
   package_import_url: github://esphome/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@main
 
 wifi:
-#  on_connect:
-#    - delay: 5s  # Gives time for improv results to be transmitted
-#    - ble.disable:
-#  on_disconnect:
-#    - ble.enable:
   ap:
 
 improv_serial:
-
-#esp32_improv:
-#  authorizer: none
 
 button:
   - platform: factory_reset

--- a/wake-word-voice-assistant/m5stack-atom-echo.yaml
+++ b/wake-word-voice-assistant/m5stack-atom-echo.yaml
@@ -346,7 +346,7 @@ file:
 micro_wake_word:
   on_wake_word_detected:
     - voice_assistant.start:
-        wake_word: !lambda return wake_word; 
+        wake_word: !lambda return wake_word;
   vad:
   models:
     - model: ${micro_wake_word_model}


### PR DESCRIPTION
Micro wake word 2 is possible on the M5 Stack Atom Echo since 2024.7.0
However it's end of speech detection was affected greatly by the issue fixed in https://github.com/esphome/esphome/pull/7109 so this version targets 2024.7.1

This firmware is adapted from `https://github.com/esphome/firmware/blob/main/voice-assistant/m5stack-atom-echo.yaml`

There are some notable changes:
 - Micro wake word 2 is enabled, with a default of 'okay_nabu'.
 - The `use_wake_word` toggle that used to switch between steamed audio to 'click to converse' is replaced by a toggle `use_micro_wake_word` that switches between micro wake word and steamed audio.
 - No more click to converse
 - A new teal light colour when not using micro_wake_word
 - Removed improv ble as
   ```
   Error: The program size (2104013 bytes) is greater than maximum allowed (1835008 bytes)
   *** [checkprogsize] Explicit exit, status 1
   ========================= [FAILED] Took 26.87 seconds =========================
   ```
---
Example firmware built on 2024.7.1 [807c9b5](https://github.com/esphome/firmware/pull/242/commits/807c9b576a7b8e32d78e40b7af98922256586001) which can be flashed by https://web.esphome.io/
```yaml
substitutions:
  name: m5stack-atom-echo
  friendly_name: M5Stack Atom Echo
  micro_wake_word_model: okay_nabu # hey_jarvis and hey_mycroft are also supported
packages:
  m5stack.atom-echo-wake-word-voice-assistant: github://HarvsG/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@patch-3
esphome:
  name: ${name}
  name_add_mac_suffix: True
  friendly_name: ${friendly_name}
```

```
RAM:   [=         ]  11.1% (used 36528 bytes from 327680 bytes)
Flash: [========= ]  85.5% (used 1569821 bytes from 1835008 bytes)
```
(Note because the URLs in the firmware point towards this repo, if you try to adopt via the ESPHome dashboard it will overwrite this PR with the old, non mww2 firmware until this is merged)

---
Until merge, if you would like to install your own via ESPHome dashboard then this config should work

```yaml
substitutions:
  name: m5stack-atom-echo
  friendly_name: M5Stack Atom Echo
  micro_wake_word_model: okay_nabu # hey_jarvis and hey_mycroft are also supported
packages:
  m5stack.atom-echo-wake-word-voice-assistant: github://HarvsG/firmware/wake-word-voice-assistant/m5stack-atom-echo.yaml@patch-3
esphome:
  name: ${name}
  name_add_mac_suffix: True
  friendly_name: ${friendly_name}
api:
  encryption:
    key: SOMEAPIKEY
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```