### PR TITLE
Add new adopted config for atom echo VA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           sed -i 's/${{ steps.esphome-build.outputs.name }}\//\/${{ matrix.firmware }}\/${{ matrix.device }}\//g' output/${{ matrix.device }}/manifest.json
       - uses: actions/upload-artifact@v4.3.4
+        if: ! contains(matrix.device, 'adopted')
         with:
           name: build-${{ matrix.firmware }}-${{ matrix.device }}
           path: output

--- a/voice-assistant/m5stack-atom-echo.adopted.yaml
+++ b/voice-assistant/m5stack-atom-echo.adopted.yaml
@@ -13,6 +13,10 @@ esp32:
 logger:
 api:
 
+ota:
+  - platform: esphome
+    id: ota_esphome
+
 wifi:
   ap:
 

--- a/voice-assistant/m5stack-atom-echo.adopted.yaml
+++ b/voice-assistant/m5stack-atom-echo.adopted.yaml
@@ -4,9 +4,6 @@ esphome:
   friendly_name: M5Stack Atom Echo
   min_version: 2024.6.0
   name_add_mac_suffix: true
-  project:
-    name: m5stack.atom-echo-voice-assistant
-    version: "24.7.4.1"
 
 esp32:
   board: m5stack-atom
@@ -16,35 +13,8 @@ esp32:
 logger:
 api:
 
-ota:
-  - platform: esphome
-    id: ota_esphome
-  - platform: http_request
-    id: ota_http_request
-
-update:
-  - platform: http_request
-    id: update_http_request
-    name: Firmware
-    source: https://firmware.esphome.io/voice-assistant/m5stack-atom-echo/manifest.json
-
-http_request:
-
-dashboard_import:
-  package_import_url: github://esphome/firmware/voice-assistant/m5stack-atom-echo.adopted.yaml@main
-
 wifi:
-  on_connect:
-    - delay: 5s  # Gives time for improv results to be transmitted
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
-
-improv_serial:
-
-esp32_improv:
-  authorizer: none
 
 button:
   - platform: safe_mode


### PR DESCRIPTION
With the recent additions to the firmware, it got too large to OTA update after adopting it.

Since http ota, update, improv, esp32_improv, dashboard_import are not needed once a device has been adopted and is now under the control of the user we can provide a smaller yaml that is used when adopted.

```
RAM:   [=         ]  10.5% (used 34500 bytes from 327680 bytes)
Flash: [======    ]  62.2% (used 1141005 bytes from 1835008 bytes)
```