### PR TITLE
Add generation script and update files

### DIFF
--- a/esphome-web/esp32.factory.yaml
+++ b/esphome-web/esp32.factory.yaml
@@ -1,11 +1,27 @@
-packages:
-  esp32: !include esp32.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp32:
+  variant: esp32
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,6 +34,7 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp32.yaml@main
   import_full_config: true

--- a/esphome-web/esp32.yaml
+++ b/esphome-web/esp32.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32dev
+  variant: esp32
   framework:
     type: esp-idf
 
@@ -20,3 +20,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/esp32c3.factory.yaml
+++ b/esphome-web/esp32c3.factory.yaml
@@ -1,11 +1,27 @@
-packages:
-  esp32c3: !include esp32c3.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp32:
+  variant: esp32c3
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,6 +34,7 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp32c3.yaml@main
   import_full_config: true

--- a/esphome-web/esp32c3.yaml
+++ b/esphome-web/esp32c3.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
     type: esp-idf
 
@@ -20,3 +20,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/esp32c6.factory.yaml
+++ b/esphome-web/esp32c6.factory.yaml
@@ -1,11 +1,27 @@
-packages:
-  esp32c3: !include esp32c6.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp32:
+  variant: esp32c6
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,11 +34,12 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp32c6.yaml@main
   import_full_config: true
 
 # Sets up Bluetooth LE (Only on ESP32) to allow the user
 # to provision wifi credentials to the device.
-# esp32_improv:
-#   authorizer: none
+esp32_improv:
+  authorizer: none

--- a/esphome-web/esp32c6.yaml
+++ b/esphome-web/esp32c6.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-c6-devkitm-1
+  variant: esp32c6
   framework:
     type: esp-idf
 
@@ -20,3 +20,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/esp32s2.factory.yaml
+++ b/esphome-web/esp32s2.factory.yaml
@@ -1,11 +1,27 @@
-packages:
-  esp32s2: !include esp32s2.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp32:
+  variant: esp32s2
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,6 +34,7 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp32s2.yaml@main
   import_full_config: true

--- a/esphome-web/esp32s2.yaml
+++ b/esphome-web/esp32s2.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-s2-saola-1
+  variant: esp32s2
   framework:
     type: esp-idf
 
@@ -20,3 +20,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/esp32s3.factory.yaml
+++ b/esphome-web/esp32s3.factory.yaml
@@ -1,11 +1,27 @@
-packages:
-  esp32s3: !include esp32s3.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,6 +34,7 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp32s3.yaml@main
   import_full_config: true

--- a/esphome-web/esp32s3.yaml
+++ b/esphome-web/esp32s3.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
     type: esp-idf
 
@@ -20,3 +20,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/esp8266.factory.yaml
+++ b/esphome-web/esp8266.factory.yaml
@@ -1,11 +1,25 @@
-packages:
-  esp8266: !include esp8266.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
+
+esp8266:
+  board: esp01_1m
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
 
 # Allow provisioning Wi-Fi via serial
 improv_serial:
@@ -18,6 +32,7 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/esp8266.yaml@main
   import_full_config: true

--- a/esphome-web/esp8266.yaml
+++ b/esphome-web/esp8266.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 esp8266:
@@ -18,3 +18,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome-web/pico-w.factory.yaml
+++ b/esphome-web/pico-w.factory.yaml
@@ -1,15 +1,34 @@
-packages:
-  pico-w: !include pico-w.yaml
 
 esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: 2025.9.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
     version: dev
 
+rp2040:
+  board: rpipicow
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
+
 # Allow provisioning Wi-Fi via serial
 improv_serial:
 
+wifi:
+  # Set up a wifi access point
+  ap: {}
+
+# Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
   package_import_url: github://esphome/firmware/esphome-web/pico-w.yaml@main
   import_full_config: true

--- a/esphome-web/pico-w.yaml
+++ b/esphome-web/pico-w.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.5.0
+  min_version: 2025.9.0
   name_add_mac_suffix: true
 
 rp2040:
@@ -18,3 +18,5 @@ ota:
   - platform: esphome
 
 wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,100 @@
+# Scripts
+
+This directory contains utility scripts for maintaining the ESPHome firmware configurations.
+
+## generate_esphome_web_configs.py
+
+Generates all ESPHome Web configuration files from templates based on platform-specific settings.
+
+### Features
+
+- **Platform Support**: Generates configs for ESP32 variants, ESP8266, and Raspberry Pi Pico W
+- **Bluetooth Awareness**: Automatically excludes Bluetooth features for platforms that don't support it:
+  - ESP8266
+  - ESP32-S2  
+  - Raspberry Pi Pico W
+- **Template-based**: Uses consistent templates for base and factory configurations
+- **Automatic File Generation**: Creates both regular and factory YAML files for each platform
+
+### Platform Configurations
+
+| Platform | Variant/Board | Framework | Bluetooth | Min Version |
+| -------- | ------------- | --------- | --------- | ----------- |
+| ESP32    | esp32         | ESP-IDF   | ✅         | 2025.9.0    |
+| ESP32-C3 | esp32c3       | ESP-IDF   | ✅         | 2025.9.0    |
+| ESP32-C6 | esp32c6       | ESP-IDF   | ✅         | 2025.9.0    |
+| ESP32-S2 | esp32s2       | ESP-IDF   | ❌         | 2025.9.0    |
+| ESP32-S3 | esp32s3       | ESP-IDF   | ✅         | 2025.9.0    |
+| ESP8266  | esp01_1m      | Arduino   | ❌         | 2025.9.0    |
+| Pico W   | rpipicow      | Arduino   | ❌         | 2025.9.0    |
+
+### Usage
+
+```bash
+# Run from the repository root
+python3 scripts/generate_esphome_web_configs.py
+
+# Or run directly (script is executable)
+./scripts/generate_esphome_web_configs.py
+```
+
+### Generated Files
+
+The script generates files in the `esphome-web/` directory:
+
+**Base configurations** (for taking control with secrets):
+- `esp32.yaml`
+- `esp32c3.yaml` 
+- `esp32c6.yaml`
+- `esp32s2.yaml`
+- `esp32s3.yaml`
+- `esp8266.yaml`
+- `pico-w.yaml`
+
+**Factory configurations** (for distribution with provisioning):
+- `esp32.factory.yaml`
+- `esp32c3.factory.yaml`
+- `esp32c6.factory.yaml` 
+- `esp32s2.factory.yaml`
+- `esp32s3.factory.yaml`
+- `esp8266.factory.yaml`
+- `pico-w.factory.yaml`
+
+### Configuration Differences
+
+#### Base vs Factory Configurations
+
+**Base configurations** include:
+- WiFi credentials from secrets
+- Basic ESPHome, API, OTA, and logging components
+
+**Factory configurations** include:
+- WiFi AP mode for provisioning
+- Captive portal for WiFi setup
+- Serial provisioning (`improv_serial`)
+- Dashboard import URLs
+- Bluetooth provisioning (`esp32_improv`) for supported platforms
+- Project metadata
+
+#### Bluetooth Support
+
+Platforms **with** Bluetooth support get:
+- `esp32_improv` component for Bluetooth provisioning
+
+Platforms **without** Bluetooth support:
+- ESP8266: Limited hardware capabilities
+- ESP32-S2: No Bluetooth radio
+- Raspberry Pi Pico W: No Bluetooth support in ESPHome
+
+### Customization
+
+To modify the generated configurations:
+
+1. Edit the `PLATFORMS` dictionary in the script
+2. Modify the `create_base_config()` or `create_factory_config()` functions
+3. Run the script to regenerate all files
+
+### Dependencies
+
+- Python 3.13+
+- No external dependencies (uses only standard library)

--- a/scripts/generate_esphome_web_configs.py
+++ b/scripts/generate_esphome_web_configs.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Script to generate ESPHome Web configuration files from templates.
+
+This script generates both regular and factory configurations for different
+ESP32 variants, ESP8266, and Raspberry Pi Pico W platforms.
+
+Requires Python 3.13+ for modern typing features (TypedDict, Literal, etc.)
+
+Usage:
+    python3 scripts/generate_esphome_web_configs.py
+"""
+
+import sys
+from pathlib import Path
+from typing import Literal, NotRequired, TypedDict
+
+# Check Python version
+if sys.version_info < (3, 13):
+    print("Error: This script requires Python 3.13 or higher")
+    print(f"Current version: {sys.version}")
+    sys.exit(1)
+
+# Configuration constants
+MIN_VERSION: str = "2025.9.0"
+
+# Type definitions for platform configuration
+PlatformKey = Literal["esp32", "esp8266", "rp2040"]
+
+
+class FrameworkConfig(TypedDict):
+    type: Literal["arduino", "esp-idf"]
+
+
+class BoardConfig(TypedDict, total=False):
+    # ESP32 platforms use variant
+    variant: Literal["esp32", "esp32c3", "esp32c6", "esp32s2", "esp32s3"]
+    framework: FrameworkConfig
+    # ESP8266 and RP2040 use board
+    board: Literal["esp01_1m", "rpipicow"]
+
+
+class PlatformConfig(TypedDict):
+    board_config: BoardConfig
+    has_bluetooth: bool
+    has_captive_portal: bool
+    platform_key: NotRequired[PlatformKey]
+
+
+# Platform configurations
+PLATFORMS: dict[str, PlatformConfig] = {
+    "esp32": {
+        "board_config": {"variant": "esp32", "framework": {"type": "esp-idf"}},
+        "has_bluetooth": True,
+        "has_captive_portal": True,
+    },
+    "esp32c3": {
+        "board_config": {"variant": "esp32c3", "framework": {"type": "esp-idf"}},
+        "has_bluetooth": True,
+        "has_captive_portal": True,
+    },
+    "esp32c6": {
+        "board_config": {"variant": "esp32c6", "framework": {"type": "esp-idf"}},
+        "has_bluetooth": True,
+        "has_captive_portal": True,
+    },
+    "esp32s2": {
+        "board_config": {"variant": "esp32s2", "framework": {"type": "esp-idf"}},
+        "has_bluetooth": False,
+        "has_captive_portal": True,
+    },
+    "esp32s3": {
+        "board_config": {"variant": "esp32s3", "framework": {"type": "esp-idf"}},
+        "has_bluetooth": True,
+        "has_captive_portal": True,
+    },
+    "esp8266": {
+        "board_config": {"board": "esp01_1m"},
+        "has_bluetooth": False,
+        "has_captive_portal": True,
+        "platform_key": "esp8266",
+    },
+    "pico-w": {
+        "board_config": {"board": "rpipicow"},
+        "has_bluetooth": False,
+        "has_captive_portal": False,
+        "platform_key": "rp2040",
+    },
+}
+
+
+def create_base_config(platform_name: str, platform_config: PlatformConfig) -> str:
+    """Create the base configuration for a platform."""
+    # Build platform section
+    platform_key: str = platform_config.get("platform_key", "esp32")
+    platform_section: str = f"{platform_key}:\n"
+
+    board_config: BoardConfig = platform_config["board_config"]
+    for key, value in board_config.items():
+        if isinstance(value, dict):
+            platform_section += f"  {key}:\n"
+            for sub_key, sub_value in value.items():
+                platform_section += f"    {sub_key}: {sub_value}\n"
+        else:
+            platform_section += f"  {key}: {value}\n"
+
+    # Combine all sections
+    config: str = f"""
+esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: {MIN_VERSION}
+  name_add_mac_suffix: true
+
+{platform_section}
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+"""
+
+    return config.strip()
+
+
+def create_factory_config(platform_name: str, platform_config: PlatformConfig) -> str:
+    """Create the factory configuration for a platform."""
+    # Build platform section
+    platform_key: str = platform_config.get("platform_key", "esp32")
+    platform_section: str = f"{platform_key}:\n"
+
+    board_config: BoardConfig = platform_config["board_config"]
+    for key, value in board_config.items():
+        if isinstance(value, dict):
+            platform_section += f"  {key}:\n"
+            for sub_key, sub_value in value.items():
+                platform_section += f"    {sub_key}: {sub_value}\n"
+        else:
+            platform_section += f"  {key}: {value}\n"
+
+    # Build the factory config with full configuration
+    config: str = f"""
+esphome:
+  name: esphome-web
+  friendly_name: ESPHome Web
+  min_version: {MIN_VERSION}
+  name_add_mac_suffix: true
+  project:
+    name: esphome.web
+    version: dev
+
+{platform_section}
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+  - platform: esphome
+
+# Allow provisioning Wi-Fi via serial
+improv_serial:
+
+wifi:
+  # Set up a wifi access point
+  ap: {{}}"""
+
+    # Add captive portal for platforms that support it
+    has_captive_portal: bool = platform_config.get("has_captive_portal", True)
+    if has_captive_portal:
+        config += """
+
+# In combination with the `ap` this allows the user
+# to provision wifi credentials to the device via WiFi AP.
+captive_portal:"""
+
+    config += f"""
+
+# Allows taking control of the device in the ESPHome Builder/Dashboard
+dashboard_import:
+  package_import_url: github://esphome/firmware/esphome-web/{platform_name}.yaml@main
+  import_full_config: true"""
+
+    # Add Bluetooth support for platforms that support it
+    has_bluetooth: bool = platform_config["has_bluetooth"]
+    if has_bluetooth:
+        config += """
+
+# Sets up Bluetooth LE (Only on ESP32) to allow the user
+# to provision wifi credentials to the device.
+esp32_improv:
+  authorizer: none"""
+
+    config += "\n"
+    return config
+
+
+def write_yaml_file(filepath: str | Path, config: str) -> None:
+    """Write configuration to YAML file with proper formatting."""
+    # Ensure directory exists using pathlib
+    Path(filepath).parent.mkdir(parents=True, exist_ok=True)
+
+    with open(filepath, "w") as f:
+        f.write(config)
+
+    print(f"Generated: {filepath}")
+
+
+def main() -> None:
+    """Generate all ESPHome Web configuration files."""
+    script_dir: Path = Path(__file__).parent
+    repo_root: Path = script_dir.parent
+    esphome_web_dir: Path = repo_root / "esphome-web"
+
+    print("Generating ESPHome Web configuration files...")
+    print(f"Output directory: {esphome_web_dir}")
+
+    for platform_name, platform_config in PLATFORMS.items():
+        # Generate base configuration
+        base_config: str = create_base_config(platform_name, platform_config)
+        base_filepath: Path = esphome_web_dir / f"{platform_name}.yaml"
+        write_yaml_file(base_filepath, base_config)
+
+        # Generate factory configuration
+        factory_config: str = create_factory_config(platform_name, platform_config)
+        factory_filepath: Path = esphome_web_dir / f"{platform_name}.factory.yaml"
+        write_yaml_file(factory_filepath, factory_config)
+
+    print("\nGeneration complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The existing files did not work well with `take contrll` as the yaml file locally had simply a `wifi:` block which is invalid (ESPHome requires either `ssid`, `ap`/`captive_portal` or `improv_serial`/`esp32_improv`)

So while updating the yaml files, I though it would be better to make a generation script for them for easier future maintenance since the files are mostly the same.