### PR TITLE
fix url in package_import_url

### DIFF
--- a/esp-web-tools/esp32.yaml
+++ b/esp-web-tools/esp32.yaml
@@ -39,7 +39,7 @@ wifi:
 captive_portal:
 
 dashboard_import:
-  package_import_url: github://esphome/example-configs/esp-web-tools/esp32.yaml@main
+  package_import_url: github://esphome/firmware/esp-web-tools/esp32.yaml@main
 
 # Sets up Bluetooth LE (Only on ESP32) to allow the user
 # to provision wifi credentials to the device.

--- a/esp-web-tools/esp8266.yaml
+++ b/esp-web-tools/esp8266.yaml
@@ -37,7 +37,7 @@ wifi:
 captive_portal:
 
 dashboard_import:
-  package_import_url: github://esphome/example-configs/esp-web-tools/esp8266.yaml@main
+  package_import_url: github://esphome/firmware/esp-web-tools/esp8266.yaml@main
 
 # To have a "next url" for improv serial
 web_server:


### PR DESCRIPTION
The `package_import_url`s in `esp-web-tools/esp32.yaml` and `esp-web-tools/esp8266.yaml` were incorrect, showing the old name of the repo. Corrected to present name of the repo.