### PR TITLE
Add esphome-web firmware for Raspberry Pi Pico 2 W

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         esphome-web/esp32s3.factory.yaml
         esphome-web/esp8266.factory.yaml
         esphome-web/pico-w.factory.yaml
+        esphome-web/pico-2-w.factory.yaml
       esphome-version: 2026.4.1
       combined-name: esphome-web
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}

--- a/.github/workflows/check-generated-configs.yml
+++ b/.github/workflows/check-generated-configs.yml
@@ -1,0 +1,37 @@
+name: Check generated configs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "esphome-web/**"
+      - "scripts/generate_esphome_web_configs.py"
+      - ".github/workflows/check-generated-configs.yml"
+  pull_request:
+    paths:
+      - "esphome-web/**"
+      - "scripts/generate_esphome_web_configs.py"
+      - ".github/workflows/check-generated-configs.yml"
+
+jobs:
+  check-esphome-web-configs:
+    name: 🤖 esphome-web configs match generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out configuration from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: 🔄 Regenerate esphome-web configs
+        run: python3 scripts/generate_esphome_web_configs.py
+      - name: ✅ Verify no changes
+        run: |
+          if [ -n "$(git status --porcelain -- esphome-web/)" ]; then
+            echo "::error::esphome-web/ is out of sync with scripts/generate_esphome_web_configs.py"
+            echo "Edit the generator script and re-run: python3 scripts/generate_esphome_web_configs.py"
+            git status --short -- esphome-web/
+            git --no-pager diff -- esphome-web/
+            exit 1
+          fi

--- a/esphome-web/esp32.factory.yaml
+++ b/esphome-web/esp32.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web

--- a/esphome-web/esp32.yaml
+++ b/esphome-web/esp32.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 esp32:

--- a/esphome-web/esp32c3.factory.yaml
+++ b/esphome-web/esp32c3.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web

--- a/esphome-web/esp32c3.yaml
+++ b/esphome-web/esp32c3.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 esp32:

--- a/esphome-web/esp32c6.factory.yaml
+++ b/esphome-web/esp32c6.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web

--- a/esphome-web/esp32s2.yaml
+++ b/esphome-web/esp32s2.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 esp32:

--- a/esphome-web/esp32s3.factory.yaml
+++ b/esphome-web/esp32s3.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web

--- a/esphome-web/esp32s3.yaml
+++ b/esphome-web/esp32s3.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 esp32:

--- a/esphome-web/esp8266.factory.yaml
+++ b/esphome-web/esp8266.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web

--- a/esphome-web/esp8266.yaml
+++ b/esphome-web/esp8266.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 esp8266:

--- a/esphome-web/pico-2-w.factory.yaml
+++ b/esphome-web/pico-2-w.factory.yaml
@@ -7,10 +7,8 @@ esphome:
     name: esphome.web
     version: dev
 
-esp32:
-  variant: esp32s2
-  framework:
-    type: esp-idf
+rp2040:
+  board: rpipico2w
 
 # Enable logging
 logger:
@@ -35,5 +33,5 @@ captive_portal:
 
 # Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:
-  package_import_url: github://esphome/firmware/esphome-web/esp32s2.yaml@main
+  package_import_url: github://esphome/firmware/esphome-web/pico-2-w.yaml@main
   import_full_config: true

--- a/esphome-web/pico-2-w.yaml
+++ b/esphome-web/pico-2-w.yaml
@@ -4,10 +4,8 @@ esphome:
   min_version: 2026.4.0
   name_add_mac_suffix: true
 
-esp32:
-  variant: esp32c6
-  framework:
-    type: esp-idf
+rp2040:
+  board: rpipico2w
 
 # Enable logging
 logger:

--- a/esphome-web/pico-w.factory.yaml
+++ b/esphome-web/pico-w.factory.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   project:
     name: esphome.web
@@ -26,6 +26,10 @@ improv_serial:
 wifi:
   # Set up a wifi access point
   ap: {}
+
+# In combination with the `ap` this allows the user
+# to provision wifi credentials to the device via WiFi AP.
+captive_portal:
 
 # Allows taking control of the device in the ESPHome Builder/Dashboard
 dashboard_import:

--- a/esphome-web/pico-w.yaml
+++ b/esphome-web/pico-w.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: esphome-web
   friendly_name: ESPHome Web
-  min_version: 2025.11.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
 
 rp2040:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,13 +20,14 @@ Generates all ESPHome Web configuration files from templates based on platform-s
 
 | Platform | Variant/Board | Framework | Bluetooth | Min Version |
 | -------- | ------------- | --------- | --------- | ----------- |
-| ESP32    | esp32         | ESP-IDF   | ✅         | 2025.9.0    |
-| ESP32-C3 | esp32c3       | ESP-IDF   | ✅         | 2025.9.0    |
-| ESP32-C6 | esp32c6       | ESP-IDF   | ✅         | 2025.9.0    |
-| ESP32-S2 | esp32s2       | ESP-IDF   | ❌         | 2025.9.0    |
-| ESP32-S3 | esp32s3       | ESP-IDF   | ✅         | 2025.9.0    |
-| ESP8266  | esp01_1m      | Arduino   | ❌         | 2025.9.0    |
-| Pico W   | rpipicow      | Arduino   | ❌         | 2025.9.0    |
+| ESP32    | esp32         | ESP-IDF   | ✅         | 2026.4.0    |
+| ESP32-C3 | esp32c3       | ESP-IDF   | ✅         | 2026.4.0    |
+| ESP32-C6 | esp32c6       | ESP-IDF   | ✅         | 2026.4.0    |
+| ESP32-S2 | esp32s2       | ESP-IDF   | ❌         | 2026.4.0    |
+| ESP32-S3 | esp32s3       | ESP-IDF   | ✅         | 2026.4.0    |
+| ESP8266  | esp01_1m      | Arduino   | ❌         | 2026.4.0    |
+| Pico W   | rpipicow      | Arduino   | ❌         | 2026.4.0    |
+| Pico 2 W | rpipico2w     | Arduino   | ❌         | 2026.4.0    |
 
 ### Usage
 
@@ -50,6 +51,7 @@ The script generates files in the `esphome-web/` directory:
 - `esp32s3.yaml`
 - `esp8266.yaml`
 - `pico-w.yaml`
+- `pico-2-w.yaml`
 
 **Factory configurations** (for distribution with provisioning):
 - `esp32.factory.yaml`
@@ -59,6 +61,7 @@ The script generates files in the `esphome-web/` directory:
 - `esp32s3.factory.yaml`
 - `esp8266.factory.yaml`
 - `pico-w.factory.yaml`
+- `pico-2-w.factory.yaml`
 
 ### Configuration Differences
 
@@ -84,7 +87,7 @@ Platforms **with** Bluetooth support get:
 Platforms **without** Bluetooth support:
 - ESP8266: Limited hardware capabilities
 - ESP32-S2: No Bluetooth radio
-- Raspberry Pi Pico W: No Bluetooth support in ESPHome
+- Raspberry Pi Pico W / Pico 2 W: No BLE provisioning component in ESPHome (the chip's BLE radio is supported via `rp2040_ble`, but there is no equivalent of `esp32_improv`)
 
 ### Customization
 

--- a/scripts/generate_esphome_web_configs.py
+++ b/scripts/generate_esphome_web_configs.py
@@ -22,7 +22,7 @@ if sys.version_info < (3, 13):
     sys.exit(1)
 
 # Configuration constants
-MIN_VERSION: str = "2025.9.0"
+MIN_VERSION: str = "2026.4.0"
 
 # Type definitions for platform configuration
 PlatformKey = Literal["esp32", "esp8266", "rp2040"]
@@ -37,7 +37,7 @@ class BoardConfig(TypedDict, total=False):
     variant: Literal["esp32", "esp32c3", "esp32c6", "esp32s2", "esp32s3"]
     framework: FrameworkConfig
     # ESP8266 and RP2040 use board
-    board: Literal["esp01_1m", "rpipicow"]
+    board: Literal["esp01_1m", "rpipicow", "rpipico2w"]
 
 
 class PlatformConfig(TypedDict):
@@ -83,7 +83,13 @@ PLATFORMS: dict[str, PlatformConfig] = {
     "pico-w": {
         "board_config": {"board": "rpipicow"},
         "has_bluetooth": False,
-        "has_captive_portal": False,
+        "has_captive_portal": True,
+        "platform_key": "rp2040",
+    },
+    "pico-2-w": {
+        "board_config": {"board": "rpipico2w"},
+        "has_bluetooth": False,
+        "has_captive_portal": True,
         "platform_key": "rp2040",
     },
 }


### PR DESCRIPTION
## Summary

Adds `esphome-web/pico-2-w.yaml` and `esphome-web/pico-2-w.factory.yaml` for the Raspberry Pi Pico 2 W (`rpipico2w` board on the `rp2040` platform), and wires the new factory config into the build matrix in `.github/workflows/build.yml`.

Bumps `min_version` across all configs to 2026.4.0 — Pico 2 W (RP2350) reached first-class platform support in ESPHome 2026.3.0, and 2026.4.0 is the current shipping version.

Also enables `captive_portal` on the rp2040/rp2350 factory configs (pico-w and pico-2-w), now that it is supported on that platform.

Generator script (`scripts/generate_esphome_web_configs.py`) is updated to know about the new platform and the bumped min version; the README table and file list are kept in sync.

Adds a new `Check generated configs` workflow (`.github/workflows/check-generated-configs.yml`) that re-runs the generator on PRs touching `esphome-web/**` or the script and fails if the result diverges from what is checked in, so the generated configs can't be edited manually.