### PR TITLE
Remove pico-2-w from esphome-web build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         esphome-web/esp32s3.factory.yaml
         esphome-web/esp8266.factory.yaml
         esphome-web/pico-w.factory.yaml
-        esphome-web/pico-2-w.factory.yaml
       esphome-version: 2026.5.0
       combined-name: esphome-web
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}


### PR DESCRIPTION
The pico-2-w factory firmware is currently clobbering the rp2040 firmware output in the combined esphome-web build. Drop it from the matrix until the output collision is resolved.