### PR TITLE
Adopt ready-made project template CI and release standards

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,12 @@
 {
   "name": "ESPHome - Firmware",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "postCreateCommand": "pip3 install esphome",
   "runArgs": ["--device=/dev/bus/usb", "--privileged"],
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli": {}
-  },
+  "features": { "ghcr.io/devcontainers/features/github-cli": {} },
   "customizations": {
     "vscode": {
-      "settings": {
-        "esphome.validator": "local"
-      },
+      "settings": { "esphome.validator": "local" },
       "extensions": ["ESPHome.esphome-vscode"]
     }
   }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,7 @@ body:
         - ESP8266
         - ESP32
         - ESP32-C3
+        - ESP32-C6
         - ESP32-S2
         - ESP32-S3
         - RP2040

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,6 +34,7 @@ body:
         - ESP32-S2
         - ESP32-S3
         - RP2040
+        - RP2350
 
   - type: input
     id: board

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,13 +2,16 @@ blank_issues_enabled: false
 contact_links:
   - name: Generic ESPHome issue
     url: https://github.com/esphome/esphome/issues
-    about: Report an issue with ESPHome compiling unrelated to these specific firmwares.
+    about: Report an issue with ESPHome itself, unrelated to these specific firmwares.
+  - name: Feature Request
+    url: https://github.com/orgs/esphome/discussions
+    about: Create a discussion on the ESPHome discussion board if you have a feature request.
   - name: Bluetooth Proxy issue
     url: https://github.com/esphome/bluetooth-proxies/issues
     about: Please search for or create an issue in the bluetooth-proxies repository.
   - name: Voice Assistant issue
     url: https://github.com/esphome/wake-word-voice-assistant/issues
-    about: Please search for or create an issue in the bluetooth-proxies repository.
+    about: Please search for or create an issue in the wake-word-voice-assistant repository.
   - name: Media Player issue
     url: https://github.com/esphome/media-players/issues
-    about: Please search for or create an issue in the bluetooth-proxies repository.
+    about: Please search for or create an issue in the media-players repository.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+# What does this implement/fix?
+
+<!-- Quick description and explanation of changes -->
+
+## Types of changes
+
+<!-- Release notes are generated from PR labels, so apply the matching label as well. -->
+
+- [ ] Bugfix (non-breaking change which fixes an issue) — label: `bugfix`
+- [ ] Enhancement (non-breaking change which improves an existing configuration) — label: `enhancement`
+- [ ] Breaking change (fix or change that alters existing behaviour, e.g. renamed entities) — label: `breaking-change`
+- [ ] Dependency update (actions, reusable workflows or ESPHome version) — label: `dependencies`
+- [ ] Other
+
+**Related issue (if applicable):**
+
+- fixes <link to issue>
+
+## Checklist
+
+- [ ] The configuration compiles and has been tested on a real device where possible.
+- [ ] `yamllint --strict .` passes.
+
+If `esphome-web` configurations were changed:
+
+- [ ] The change was made in `scripts/generate_esphome_web_configs.py` (not by hand-editing the generated YAML) and the configs were regenerated with `python3 scripts/generate_esphome_web_configs.py`.
+
+If a configuration was added or renamed:
+
+- [ ] It follows the naming convention CI discovers automatically: `esp-web-tools/<chip>.yaml` or `esphome-web/<chip>.factory.yaml` — no `build.yml` edits needed.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "Enhancements"
+    label: "enhancement"
+  - title: "Bug Fixes"
+    label: "bugfix"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+# Version is calculated externally (calver YY.M.N) and passed in as an input,
+# so the version-resolver here is unused. The workflow overrides
+# `name`, `tag`, and `version`.
+
+template: |
+  > [!CAUTION]
+  > **DO NOT PUBLISH THIS RELEASE YET!**
+  > Build assets have not been uploaded. Wait for the build workflow to complete
+  > and this notice to be removed before publishing.
+  <!-- ASSETS_PENDING -->
+
+  ## What's Changed
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,15 +2,19 @@ name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 categories:
   - title: "Breaking Changes"
-    label: "breaking-change"
+    when:
+      label: "breaking-change"
   - title: "Enhancements"
-    label: "enhancement"
+    when:
+      label: "enhancement"
   - title: "Bug Fixes"
-    label: "bugfix"
+    when:
+      label: "bugfix"
   - title: "Dependencies"
     collapse-after: 1
-    labels:
-      - "dependencies"
+    when:
+      labels:
+        - "dependencies"
 
 # Version is calculated externally (calver YY.M.N) and passed in as an input,
 # so the version-resolver here is unused. The workflow overrides

--- a/.github/rulesets/block-release-publishing.json
+++ b/.github/rulesets/block-release-publishing.json
@@ -1,0 +1,34 @@
+{
+  "name": "Block release publishing",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 247347,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/default-protection.json
+++ b/.github/rulesets/default-protection.json
@@ -1,0 +1,61 @@
+{
+  "name": "Default protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": false,
+        "review_draft_pull_requests": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 247347,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,13 @@
 name: Build
+# This repository cannot use the shared build-to-draft-release.yml thin
+# caller that the other ready-made project repositories use: it builds two
+# grouped firmwares (combined-name: esp-web-tools and esphome-web), and the
+# shared workflow neither forwards a combined-name nor tolerates being
+# called twice (each call's clean-draft-assets would delete the other
+# call's assets). The draft-release jobs below are therefore kept inline,
+# byte-for-byte in sync with the 2026.7.0 implementations in
+# esphome/workflows/.github/workflows/build-to-draft-release.yml. Revisit
+# once the shared workflow supports grouped builds.
 
 on:
   pull_request:
@@ -40,12 +49,8 @@ jobs:
           esp_web_tools=$(find esp-web-tools -name '*.yaml' -print | sort)
           # esphome-web ships a <chip>.factory.yaml per platform; the plain
           # <chip>.yaml next to it is the adoptable base config, not a build
-          # target. pico-2-w is excluded until its output collision with
-          # pico-w in the combined build is resolved (see #351): needs
-          # ESPHome >= 2026.7.0 plus a build-action release that handles the
-          # rp2 platform, via a new esphome/workflows pin.
-          esphome_web=$(find esphome-web -name '*.factory.yaml' -print | sort \
-            | grep -vxF 'esphome-web/pico-2-w.factory.yaml')
+          # target.
+          esphome_web=$(find esphome-web -name '*.factory.yaml' -print | sort)
           if [[ -z "${esp_web_tools}" || -z "${esphome_web}" ]]; then
             echo "::error::No configs found"
             exit 1
@@ -82,28 +87,38 @@ jobs:
       - name: Look up draft release info
         id: info
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           tag=""
           url=""
           body=""
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+              echo "::error::Failed to list releases"
+              exit 1
+            fi
             # Ignore drafts whose tag was reset to an untagged-* placeholder
             # (a stray PATCH without tag_name causes this) — building against
             # one would bake the placeholder into the firmware as its version.
-            release_json=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first')
+            release_json=$(jq \
+              '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first' \
+              <<< "${releases}")
             if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
               echo "::error::No draft release found"
               exit 1
             fi
-            tag=$(echo "${release_json}" | jq -r '.tag_name')
-            url=$(echo "${release_json}" | jq -r '.html_url')
+            tag=$(jq -r '.tag_name' <<< "${release_json}")
+            # Do NOT use the draft's html_url: for a draft it always points
+            # at an untagged-* placeholder that 404s once the release is
+            # published. The final URL is deterministic from the tag.
+            url="https://github.com/${GH_REPO}/releases/tag/${tag}"
             # Strip the ASSETS_PENDING caution block from the draft body before
             # baking it into the firmware as release-summary; the warning is
             # only meant for the maintainer viewing the draft on GitHub.
-            body=$(echo "${release_json}" | jq -r '.body' \
+            body=$(jq -r '.body' <<< "${release_json}" \
               | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
               | sed 's/<!-- ASSETS_PENDING -->//g' \
               | sed '/./,$!d')
@@ -121,10 +136,10 @@ jobs:
     needs:
       - discover-files
       - determine-version
-    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    uses: esphome/workflows/.github/workflows/build.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       files: ${{ needs.discover-files.outputs.esp-web-tools-files }}
-      esphome-version: 2026.5.3
+      esphome-version: 2026.7.0
       combined-name: esp-web-tools
       release-summary: ${{ needs.determine-version.outputs.summary }}
       release-url: ${{ needs.determine-version.outputs.url }}
@@ -135,10 +150,10 @@ jobs:
     needs:
       - discover-files
       - determine-version
-    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    uses: esphome/workflows/.github/workflows/build.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       files: ${{ needs.discover-files.outputs.esphome-web-files }}
-      esphome-version: 2026.5.3
+      esphome-version: 2026.7.0
       combined-name: esphome-web
       release-summary: ${{ needs.determine-version.outputs.summary }}
       release-url: ${{ needs.determine-version.outputs.url }}
@@ -160,23 +175,29 @@ jobs:
     steps:
       - name: Delete existing assets from draft release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.determine-version.outputs.version }}
         run: |
           set -euo pipefail
-          tag="${{ needs.determine-version.outputs.version }}"
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+          release=$(jq --arg tag "${TAG}" \
+            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
           if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "Draft release ${tag} not found; nothing to clean"
+            echo "Draft release ${TAG} not found; nothing to clean"
             exit 0
           fi
-          release_id=$(echo "${release}" | jq -r '.id')
-          asset_ids=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --jq '.[].id')
+          release_id=$(jq -r '.id' <<< "${release}")
+          if ! asset_ids=$(gh api "repos/${GH_REPO}/releases/${release_id}/assets" --paginate --jq '.[].id'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
           for id in ${asset_ids}; do
             echo "Deleting asset ${id}"
-            gh api "repos/${{ github.repository }}/releases/assets/${id}" \
-              --method DELETE --silent
+            gh api "repos/${GH_REPO}/releases/assets/${id}" --method DELETE --silent
           done
 
   upload-to-draft-release:
@@ -191,7 +212,7 @@ jobs:
     # job must grant at least that much.
     permissions:
       contents: write
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       version: ${{ needs.determine-version.outputs.version }}
       draft: true
@@ -208,18 +229,23 @@ jobs:
     steps:
       - name: Remove ASSETS_PENDING warning from draft release body
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.determine-version.outputs.version }}
         run: |
           set -euo pipefail
-          tag="${{ needs.determine-version.outputs.version }}"
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+          release=$(jq --arg tag "${TAG}" \
+            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
           if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "Draft release ${tag} not found; nothing to clean up"
+            echo "Draft release ${TAG} not found; nothing to clean up"
             exit 0
           fi
-          release_id=$(echo "${release}" | jq -r '.id')
-          body=$(echo "${release}" | jq -r '.body')
+          release_id=$(jq -r '.id' <<< "${release}")
+          body=$(jq -r '.body' <<< "${release}")
           new_body=$(echo "${body}" \
             | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
             | sed 's/<!-- ASSETS_PENDING -->//g' \
@@ -227,11 +253,11 @@ jobs:
           if [[ "${new_body}" != "${body}" ]]; then
             # tag_name and name must be re-sent: updating a draft release
             # without them resets its tag to an untagged-* placeholder.
-            gh api "repos/${{ github.repository }}/releases/${release_id}" \
+            gh api "repos/${GH_REPO}/releases/${release_id}" \
               --method PATCH \
               --field "body=${new_body}" \
-              --field "tag_name=${tag}" \
-              --field "name=${tag}" \
+              --field "tag_name=${TAG}" \
+              --field "name=${TAG}" \
               --field "draft=true" \
               --silent
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,80 +7,213 @@ on:
       - 'esphome-web/**'
       - '.github/workflows/build.yml'
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release Drafter"]
+    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && 'release-drafter' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  discover-files:
+    name: Discover Configs
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      esp-web-tools-files: ${{ steps.find.outputs.esp-web-tools-files }}
+      esphome-web-files: ${{ steps.find.outputs.esphome-web-files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Find configs
+        id: find
+        run: |
+          set -euo pipefail
+          # The esp-web-tools demo firmware builds every plain <chip>.yaml.
+          esp_web_tools=$(find esp-web-tools -name '*.yaml' -print | sort)
+          # esphome-web ships a <chip>.factory.yaml per platform; the plain
+          # <chip>.yaml next to it is the adoptable base config, not a build
+          # target. pico-2-w is excluded until its output collision with
+          # pico-w in the combined build is resolved (see #351): needs
+          # ESPHome >= 2026.7.0 plus a build-action release that handles the
+          # rp2 platform, via a new esphome/workflows pin.
+          esphome_web=$(find esphome-web -name '*.factory.yaml' -print | sort \
+            | grep -vxF 'esphome-web/pico-2-w.factory.yaml')
+          if [[ -z "${esp_web_tools}" || -z "${esphome_web}" ]]; then
+            echo "::error::No configs found"
+            exit 1
+          fi
+          echo "Discovered esp-web-tools configs:"
+          echo "${esp_web_tools}"
+          echo "Discovered esphome-web factory configs:"
+          echo "${esphome_web}"
+          {
+            echo "esp-web-tools-files<<CONFIG_FILES_EOF"
+            echo "${esp_web_tools}"
+            echo "CONFIG_FILES_EOF"
+            echo "esphome-web-files<<CONFIG_FILES_EOF"
+            echo "${esphome_web}"
+            echo "CONFIG_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  determine-version:
+    name: Determine Version
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      summary: ${{ steps.info.outputs.summary }}
+      url: ${{ steps.info.outputs.url }}
+    steps:
+      - name: Look up draft release info
+        id: info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=""
+          url=""
+          body=""
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            release_json=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[] | select(.draft == true)] | first')
+            if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
+              echo "::error::No draft release found"
+              exit 1
+            fi
+            tag=$(echo "${release_json}" | jq -r '.tag_name')
+            url=$(echo "${release_json}" | jq -r '.html_url')
+            # Strip the ASSETS_PENDING caution block from the draft body before
+            # baking it into the firmware as release-summary; the warning is
+            # only meant for the maintainer viewing the draft on GitHub.
+            body=$(echo "${release_json}" | jq -r '.body' \
+              | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+              | sed 's/<!-- ASSETS_PENDING -->//g' \
+              | sed '/./,$!d')
+          fi
+          echo "version=${tag}" >> "$GITHUB_OUTPUT"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<RELEASE_SUMMARY_EOF"
+            echo "${body}"
+            echo "RELEASE_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
   build-esp-web-tools-firmware:
     name: ESP Web Tools
+    needs:
+      - discover-files
+      - determine-version
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
-      files: |
-        esp-web-tools/esp32.yaml
-        esp-web-tools/esp32c3.yaml
-        esp-web-tools/esp32c6.yaml
-        esp-web-tools/esp32s2.yaml
-        esp-web-tools/esp32s3.yaml
-        esp-web-tools/esp8266.yaml
+      files: ${{ needs.discover-files.outputs.esp-web-tools-files }}
       esphome-version: 2026.5.3
       combined-name: esp-web-tools
-      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
-      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
-      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+      release-summary: ${{ needs.determine-version.outputs.summary }}
+      release-url: ${{ needs.determine-version.outputs.url }}
+      release-version: ${{ needs.determine-version.outputs.version }}
 
   build-esphome-web-firmware:
     name: ESPHome Web
+    needs:
+      - discover-files
+      - determine-version
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
-      files: |
-        esphome-web/esp32.factory.yaml
-        esphome-web/esp32c3.factory.yaml
-        esphome-web/esp32c6.factory.yaml
-        esphome-web/esp32s2.factory.yaml
-        esphome-web/esp32s3.factory.yaml
-        esphome-web/esp8266.factory.yaml
-        esphome-web/pico-w.factory.yaml
+      files: ${{ needs.discover-files.outputs.esphome-web-files }}
       esphome-version: 2026.5.3
       combined-name: esphome-web
-      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
-      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
-      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+      release-summary: ${{ needs.determine-version.outputs.summary }}
+      release-url: ${{ needs.determine-version.outputs.url }}
+      release-version: ${{ needs.determine-version.outputs.version }}
 
-  upload-to-r2:
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-    name: Upload to R2
+  clean-draft-assets:
+    name: Clean Draft Release Assets
+    # Delete any pre-existing assets so renamed files (e.g. when the version
+    # bumps from .1 to .2) don't linger alongside the new ones. Gated on
+    # build success so a failed build doesn't leave the draft release empty.
+    if: github.event_name == 'workflow_run'
     needs:
       - build-esp-web-tools-firmware
       - build-esphome-web-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      directory: "."
-    secrets: inherit
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete existing assets from draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.determine-version.outputs.version }}"
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${tag} not found; nothing to clean"
+            exit 0
+          fi
+          release_id=$(echo "${release}" | jq -r '.id')
+          asset_ids=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --jq '.[].id')
+          for id in ${asset_ids}; do
+            echo "Deleting asset ${id}"
+            gh api "repos/${{ github.repository }}/releases/assets/${id}" \
+              --method DELETE --silent
+          done
 
-  upload-to-release:
-    if: github.event_name == 'release'
-    name: Upload to Release
+  upload-to-draft-release:
+    name: Upload to Draft Release
+    if: github.event_name == 'workflow_run'
     needs:
       - build-esp-web-tools-firmware
       - build-esphome-web-firmware
+      - determine-version
+      - clean-draft-assets
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
-      version: ${{ github.event.release.tag_name }}
-    secrets: inherit
+      version: ${{ needs.determine-version.outputs.version }}
+      draft: true
 
-  promote:
-    name: Promote esp-web-tools to Production
-    if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+  remove-pending-warning:
+    name: Remove Pending Warning
+    if: github.event_name == 'workflow_run'
     needs:
-      - upload-to-r2
-    with:
-      version: ${{ github.event.release.tag_name }}
-      directory: "."
-      channel: production
-      manifest-filename: manifest.json
-    secrets: inherit
+      - upload-to-draft-release
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Remove ASSETS_PENDING warning from draft release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.determine-version.outputs.version }}"
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${tag} not found; nothing to clean up"
+            exit 0
+          fi
+          release_id=$(echo "${release}" | jq -r '.id')
+          body=$(echo "${release}" | jq -r '.body')
+          new_body=$(echo "${body}" \
+            | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+            | sed 's/<!-- ASSETS_PENDING -->//g' \
+            | sed '/./,$!d')
+          if [[ "${new_body}" != "${body}" ]]; then
+            gh api "repos/${{ github.repository }}/releases/${release_id}" \
+              --method PATCH \
+              --field "body=${new_body}" \
+              --field "draft=true" \
+              --silent
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,11 @@ jobs:
           url=""
           body=""
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — building against
+            # one would bake the placeholder into the firmware as its version.
             release_json=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true)] | first')
+              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first')
             if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
               echo "::error::No draft release found"
               exit 1
@@ -222,9 +225,13 @@ jobs:
             | sed 's/<!-- ASSETS_PENDING -->//g' \
             | sed '/./,$!d')
           if [[ "${new_body}" != "${body}" ]]; then
+            # tag_name and name must be re-sent: updating a draft release
+            # without them resets its tag to an untagged-* placeholder.
             gh api "repos/${{ github.repository }}/releases/${release_id}" \
               --method PATCH \
               --field "body=${new_body}" \
+              --field "tag_name=${tag}" \
+              --field "name=${tag}" \
               --field "draft=true" \
               --silent
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     workflows: ["Release Drafter"]
     types: [completed]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && 'release-drafter' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -67,6 +70,10 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      # Draft releases are only visible to tokens with push access, so
+      # reading the draft requires contents: write despite being read-only.
+      contents: write
     outputs:
       version: ${{ steps.info.outputs.version }}
       summary: ${{ steps.info.outputs.summary }}
@@ -177,6 +184,10 @@ jobs:
       - build-esphome-web-firmware
       - determine-version
       - clean-draft-assets
+    # The reusable workflow declares contents: write on its job; the caller
+    # job must grant at least that much.
+    permissions:
+      contents: write
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
       version: ${{ needs.determine-version.outputs.version }}

--- a/.github/workflows/check-generated-configs.yml
+++ b/.github/workflows/check-generated-configs.yml
@@ -13,6 +13,9 @@ on:
       - "scripts/generate_esphome_web_configs.py"
       - ".github/workflows/check-generated-configs.yml"
 
+permissions:
+  contents: read
+
 jobs:
   check-esphome-web-configs:
     name: 🤖 esphome-web configs match generator

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    uses: esphome/workflows/.github/workflows/lock.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       pr-close-days: 1
       issue-close-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  discover-firmwares:
+    name: Discover firmwares in release
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - name: List firmwares from release manifests
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p manifests
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --dir manifests \
+            --pattern '*.manifest.json'
+          firmwares=$(ls manifests | sed 's/\.manifest\.json$//' \
+            | jq -R -s 'split("\n") | map(select(length > 0))')
+          if [[ "$(echo "${firmwares}" | jq 'length')" -eq 0 ]]; then
+            echo "::error::No <firmware>.manifest.json assets found on release"
+            exit 1
+          fi
+          echo "matrix=$(jq -c -n --argjson firmwares "${firmwares}" '{firmware: $firmwares}')" >> "$GITHUB_OUTPUT"
+          echo "Discovered firmwares: ${firmwares}"
+
+  prepare-artifact:
+    name: Prepare ${{ matrix.firmware }} artifact
+    needs: discover-firmwares
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-firmwares.outputs.matrix) }}
+    steps:
+      - name: Download firmware assets and reconstruct layout
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIRMWARE: ${{ matrix.firmware }}
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Recreate the `<version>/{manifest.json,*.bin}` layout that
+          # upload-to-r2 / promote-r2 expect from a build.yml run. The
+          # artifact name (= firmware) becomes the surrounding directory when
+          # download-artifact runs in the reusable workflows.
+          target="output/${VERSION}"
+          mkdir -p "${target}"
+
+          # Pull just this firmware's manifest first so we know which
+          # binaries to fetch — avoids each matrix runner re-downloading
+          # every other firmware's bins.
+          gh release download "${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --dir "${target}" \
+            --pattern "${FIRMWARE}.manifest.json"
+          mv "${target}/${FIRMWARE}.manifest.json" "${target}/manifest.json"
+
+          # Build a multi-pattern download for the bins the manifest
+          # references (ota + parts), then run a single gh call.
+          patterns=()
+          while IFS= read -r bin; do
+            [[ -z "${bin}" ]] && continue
+            patterns+=(--pattern "${bin}")
+          done < <(jq -r '[
+            (.builds[]?.ota.path // empty),
+            (.builds[]?.parts[]?.path // empty)
+          ] | unique | .[]' "${target}/manifest.json")
+
+          if [[ "${#patterns[@]}" -gt 0 ]]; then
+            gh release download "${VERSION}" \
+              --repo "${{ github.repository }}" \
+              --dir "${target}" \
+              "${patterns[@]}"
+          fi
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.firmware }}
+          path: output
+          if-no-files-found: error
+
+  upload-to-r2:
+    name: Upload to R2
+    needs: prepare-artifact
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      # The firmwares in this repository (esp-web-tools, esphome-web) live as
+      # top-level directories on https://firmware.esphome.io/, so upload to
+      # the bucket root rather than a per-repo directory.
+      directory: "."
+    secrets: inherit
+
+  promote-prod:
+    name: Promote to Production
+    if: github.event.release.prerelease == false
+    needs: upload-to-r2
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      version: ${{ github.event.release.tag_name }}
+      directory: "."
+      channel: production
+      manifest-filename: manifest.json
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,123 +4,23 @@ on:
   release:
     types: [published]
 
-# Jobs that download release assets request contents: read individually; the
-# upload/promote jobs only use the Cloudflare R2 secrets and never touch
-# GITHUB_TOKEN, so they run with no permissions at all.
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  discover-firmwares:
-    name: Discover firmwares in release
-    runs-on: ubuntu-latest
-    permissions:
-      # Read release assets with gh release download.
-      contents: read
-    outputs:
-      matrix: ${{ steps.find.outputs.matrix }}
-    steps:
-      - name: List firmwares from release manifests
-        id: find
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          mkdir -p manifests
-          gh release download "${{ github.event.release.tag_name }}" \
-            --repo "${{ github.repository }}" \
-            --dir manifests \
-            --pattern '*.manifest.json'
-          firmwares=$(ls manifests | sed 's/\.manifest\.json$//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
-          if [[ "$(echo "${firmwares}" | jq 'length')" -eq 0 ]]; then
-            echo "::error::No <firmware>.manifest.json assets found on release"
-            exit 1
-          fi
-          echo "matrix=$(jq -c -n --argjson firmwares "${firmwares}" '{firmware: $firmwares}')" >> "$GITHUB_OUTPUT"
-          echo "Discovered firmwares: ${firmwares}"
-
-  prepare-artifact:
-    name: Prepare ${{ matrix.firmware }} artifact
-    needs: discover-firmwares
-    runs-on: ubuntu-latest
-    permissions:
-      # Read release assets with gh release download.
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.discover-firmwares.outputs.matrix) }}
-    steps:
-      - name: Download firmware assets and reconstruct layout
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FIRMWARE: ${{ matrix.firmware }}
-          VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          set -euo pipefail
-          # Recreate the `<version>/{manifest.json,*.bin}` layout that
-          # upload-to-r2 / promote-r2 expect from a build.yml run. The
-          # artifact name (= firmware) becomes the surrounding directory when
-          # download-artifact runs in the reusable workflows.
-          target="output/${VERSION}"
-          mkdir -p "${target}"
-
-          # Pull just this firmware's manifest first so we know which
-          # binaries to fetch — avoids each matrix runner re-downloading
-          # every other firmware's bins.
-          gh release download "${VERSION}" \
-            --repo "${{ github.repository }}" \
-            --dir "${target}" \
-            --pattern "${FIRMWARE}.manifest.json"
-          mv "${target}/${FIRMWARE}.manifest.json" "${target}/manifest.json"
-
-          # Build a multi-pattern download for the bins the manifest
-          # references (ota + parts), then run a single gh call.
-          patterns=()
-          while IFS= read -r bin; do
-            [[ -z "${bin}" ]] && continue
-            patterns+=(--pattern "${bin}")
-          done < <(jq -r '[
-            (.builds[]?.ota.path // empty),
-            (.builds[]?.parts[]?.path // empty)
-          ] | unique | .[]' "${target}/manifest.json")
-
-          if [[ "${#patterns[@]}" -gt 0 ]]; then
-            gh release download "${VERSION}" \
-              --repo "${{ github.repository }}" \
-              --dir "${target}" \
-              "${patterns[@]}"
-          fi
-
-      - name: Upload firmware artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: ${{ matrix.firmware }}
-          path: output
-          if-no-files-found: error
-
-  upload-to-r2:
-    name: Upload to R2
-    needs: prepare-artifact
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+  publish:
+    name: Publish firmware to R2
+    # Downloads the release's firmware assets and uploads them to
+    # https://firmware.esphome.io/ (beta always, production for
+    # non-prerelease).
+    uses: esphome/workflows/.github/workflows/publish-firmware-to-r2.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       # The firmwares in this repository (esp-web-tools, esphome-web) live as
-      # top-level directories on https://firmware.esphome.io/, so upload to
-      # the bucket root rather than a per-repo directory.
+      # top-level directories on https://firmware.esphome.io/, so publish to
+      # the bucket root rather than the singularized-repo-name default.
       directory: "."
-    secrets: inherit
-
-  promote-prod:
-    name: Promote to Production
-    if: github.event.release.prerelease == false
-    needs: upload-to-r2
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      version: ${{ github.event.release.tag_name }}
-      directory: "."
-      channel: production
-      manifest-filename: manifest.json
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,10 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
+# Jobs that download release assets request contents: read individually; the
+# upload/promote jobs only use the Cloudflare R2 secrets and never touch
+# GITHUB_TOKEN, so they run with no permissions at all.
+permissions: {}
 
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
@@ -15,6 +17,9 @@ jobs:
   discover-firmwares:
     name: Discover firmwares in release
     runs-on: ubuntu-latest
+    permissions:
+      # Read release assets with gh release download.
+      contents: read
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
     steps:
@@ -42,6 +47,9 @@ jobs:
     name: Prepare ${{ matrix.firmware }} artifact
     needs: discover-firmwares
     runs-on: ubuntu-latest
+    permissions:
+      # Read release assets with gh release download.
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-firmwares.outputs.matrix) }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,63 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
+jobs:
+  release-drafter:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate calver version
+        id: calver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # CalVer scheme: YY.M.N
+          #   YY = year mod 100 (e.g. 2026 -> 26)
+          #   M  = month, no zero padding (e.g. April -> 4)
+          #   N  = sequential release of that month, starting at 1
+          year=$(date -u +%y)
+          month=$(date -u +%-m)
+          prefix="${year}.${month}."
+
+          # Highest existing tag (draft or published) matching the current YY.M.*
+          latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | sub(\"^${prefix}\"; \"\") | tonumber] | max // 0")
+
+          if [[ "${latest_seq}" -eq 0 ]]; then
+            seq=1
+          else
+            # If the existing release at the highest seq is still a draft, reuse it
+            # so subsequent pushes update the same draft. Otherwise start a new one.
+            is_draft=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+              --jq "[.[] | select(.tag_name == \"${prefix}${latest_seq}\")] | first | .draft")
+            if [[ "${is_draft}" == "true" ]]; then
+              seq=${latest_seq}
+            else
+              seq=$((latest_seq + 1))
+            fi
+          fi
+
+          version="${prefix}${seq}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Calculated calver version: ${version}"
+
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1
+        with:
+          version: ${{ steps.calver.outputs.version }}
+          tag: ${{ steps.calver.outputs.version }}
+          name: ${{ steps.calver.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,7 @@ jobs:
 
           # Highest existing tag (draft or published) matching the current YY.M.*
           latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | sub(\"^${prefix}\"; \"\") | tonumber] | max // 0")
+            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | ltrimstr(\"${prefix}\") | tonumber] | max // 0")
 
           if [[ "${latest_seq}" -eq 0 ]]; then
             seq=1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   release-drafter:
     name: Update draft release
-    # Never draft releases in the template repository itself.
-    if: github.event.repository.name != 'ready-made-project-template'
     # Computes the next CalVer version (YY.M.N, reusing the current draft's
     # sequence number) and runs release-drafter with it. Reads this repo's
     # .github/release-drafter.yml for the changelog categories.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,48 +16,9 @@ concurrency:
 jobs:
   release-drafter:
     name: Update draft release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Calculate calver version
-        id: calver
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # CalVer scheme: YY.M.N
-          #   YY = year mod 100 (e.g. 2026 -> 26)
-          #   M  = month, no zero padding (e.g. April -> 4)
-          #   N  = sequential release of that month, starting at 1
-          year=$(date -u +%y)
-          month=$(date -u +%-m)
-          prefix="${year}.${month}."
-
-          # Highest existing tag (draft or published) matching the current YY.M.*
-          latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | ltrimstr(\"${prefix}\") | tonumber] | max // 0")
-
-          if [[ "${latest_seq}" -eq 0 ]]; then
-            seq=1
-          else
-            # If the existing release at the highest seq is still a draft, reuse it
-            # so subsequent pushes update the same draft. Otherwise start a new one.
-            is_draft=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-              --jq "[.[] | select(.tag_name == \"${prefix}${latest_seq}\")] | first | .draft")
-            if [[ "${is_draft}" == "true" ]]; then
-              seq=${latest_seq}
-            else
-              seq=$((latest_seq + 1))
-            fi
-          fi
-
-          version="${prefix}${seq}"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Calculated calver version: ${version}"
-
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1
-        with:
-          version: ${{ steps.calver.outputs.version }}
-          tag: ${{ steps.calver.outputs.version }}
-          name: ${{ steps.calver.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Never draft releases in the template repository itself.
+    if: github.event.repository.name != 'ready-made-project-template'
+    # Computes the next CalVer version (YY.M.N, reusing the current draft's
+    # sequence number) and runs release-drafter with it. Reads this repo's
+    # .github/release-drafter.yml for the changelog categories.
+    uses: esphome/workflows/.github/workflows/draft-calver-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the token to what this job does: read the draft release,
+          # replace its manifest assets and publish it.
+          permission-contents: write
 
       - name: Resolve draft release
         id: find

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
+# Every step authenticates with the ESPHome GitHub App token (see the
+# comment on the first step); the default GITHUB_TOKEN is never used.
+permissions: {}
 
 concurrency:
   group: release-${{ inputs.tag || 'latest-draft' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (defaults to the most recent draft)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.tag || 'latest-draft' }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Patch manifests and publish
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      # We use a GitHub App token (not GITHUB_TOKEN) so that publishing the
+      # release fires a `release: published` event downstream — the default
+      # GITHUB_TOKEN intentionally does not trigger further workflows, which
+      # would leave publish.yml dormant.
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Resolve draft release
+        id: find
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG}"
+          if [[ -z "${tag}" ]]; then
+            tag=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[] | select(.draft == true)] | first | .tag_name // ""')
+          fi
+          if [[ -z "${tag}" || "${tag}" == "null" ]]; then
+            echo "::error::No draft release found"
+            exit 1
+          fi
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "::error::Draft release ${tag} not found"
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "release_id=$(echo "${release}" | jq -r '.id')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "${release}" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            echo "${release}" | jq -r '.body'
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved draft release: ${tag}"
+
+      - name: Download manifest assets
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          gh release download "${{ steps.find.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir assets \
+            --pattern '*.manifest.json'
+
+      - name: Patch manifests with current release body
+        env:
+          RELEASE_SUMMARY: ${{ steps.find.outputs.body }}
+          RELEASE_URL: ${{ steps.find.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p patched
+          for manifest in assets/*.manifest.json; do
+            jq --arg summary "${RELEASE_SUMMARY}" --arg url "${RELEASE_URL}" \
+              '.builds[].ota |= (.summary = $summary | .release_url = $url)' \
+              "${manifest}" > "patched/$(basename "${manifest}")"
+          done
+
+      - name: Re-upload patched manifests to draft release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.find.outputs.tag }}"
+          for manifest in patched/*.manifest.json; do
+            echo "Replacing ${manifest}"
+            gh release upload "${tag}" "${manifest}" \
+              --repo "${{ github.repository }}" \
+              --clobber
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh release edit "${{ steps.find.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false
+          echo "Published ${{ steps.find.outputs.tag }} — publish.yml will pick it up via release: published"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,11 @@ jobs:
           set -euo pipefail
           tag="${INPUT_TAG}"
           if [[ -z "${tag}" ]]; then
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — publishing one
+            # would create a release under the placeholder tag.
             tag=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true)] | first | .tag_name // ""')
+              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first | .tag_name // ""')
           fi
           if [[ -z "${tag}" || "${tag}" == "null" ]]; then
             echo "::error::No draft release found"
@@ -74,10 +77,27 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p assets
-          gh release download "${{ steps.find.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --dir assets \
-            --pattern '*.manifest.json'
+          # Work with the release id resolved above instead of `gh release
+          # download <tag>`: gh's draft-by-tag resolution has proven
+          # unreliable (it caused duplicate drafts in esphome/workflows'
+          # upload-to-gh-release.yml), while lookups by id always work.
+          release_id="${{ steps.find.outputs.release_id }}"
+          if ! assets=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --paginate \
+            --jq '.[] | select(.name | endswith(".manifest.json")) | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
+          if [[ -z "${assets}" ]]; then
+            echo "::error::No *.manifest.json assets found on draft release"
+            exit 1
+          fi
+          while IFS=$'\t' read -r asset_id asset_name; do
+            echo "Downloading ${asset_name}"
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${{ github.repository }}/releases/assets/${asset_id}" \
+              > "assets/${asset_name}"
+          done <<< "${assets}"
 
       - name: Patch manifests with current release body
         env:
@@ -97,12 +117,30 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
-          tag="${{ steps.find.outputs.tag }}"
+          # Upload by release id rather than `gh release upload <tag>
+          # --clobber` for the same reason as the download step: draft-by-tag
+          # resolution is unreliable. Clobber semantics are replicated by
+          # deleting any same-named asset before uploading.
+          release_id="${{ steps.find.outputs.release_id }}"
+          if ! existing=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --paginate \
+            --jq '.[] | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
           for manifest in patched/*.manifest.json; do
-            echo "Replacing ${manifest}"
-            gh release upload "${tag}" "${manifest}" \
-              --repo "${{ github.repository }}" \
-              --clobber
+            name=$(basename "${manifest}")
+            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1}' <<< "${existing}")
+            if [[ -n "${asset_id}" ]]; then
+              echo "Deleting existing asset ${name} (${asset_id})"
+              gh api "repos/${{ github.repository }}/releases/assets/${asset_id}" \
+                --method DELETE --silent
+            fi
+            echo "Uploading ${name}"
+            gh api --method POST \
+              -H "Content-Type: application/json" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${release_id}/assets?name=${name}" \
+              --input "${manifest}" --silent
           done
 
       - name: Publish release
@@ -110,7 +148,16 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
-          gh release edit "${{ steps.find.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --draft=false
-          echo "Published ${{ steps.find.outputs.tag }} — publish.yml will pick it up via release: published"
+          tag="${{ steps.find.outputs.tag }}"
+          # Publish by id, not `gh release edit <tag> --draft=false`: besides
+          # the unreliable draft-by-tag resolution, gh sends a PATCH with only
+          # draft=false — and updating a draft without re-sending tag_name
+          # resets its tag to an untagged-* placeholder, which would then be
+          # published as the release tag.
+          gh api "repos/${{ github.repository }}/releases/${{ steps.find.outputs.release_id }}" \
+            --method PATCH \
+            --field "tag_name=${tag}" \
+            --field "name=${tag}" \
+            --field "draft=false" \
+            --silent
+          echo "Published ${tag} — publish.yml will pick it up via release: published"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,156 +8,20 @@ on:
         required: false
         type: string
 
-# Every step authenticates with the ESPHome GitHub App token (see the
-# comment on the first step); the default GITHUB_TOKEN is never used.
+# The called workflow authenticates every step with the ESPHome GitHub App
+# token (via vars.ESPHOME_GITHUB_APP_CLIENT_ID and the inherited
+# ESPHOME_GITHUB_APP_PRIVATE_KEY secret) so that publishing fires a
+# `release: published` event downstream; GITHUB_TOKEN is never used. It also
+# runs in this repo's `release` environment.
 permissions: {}
-
-concurrency:
-  group: release-${{ inputs.tag || 'latest-draft' }}
-  cancel-in-progress: false
 
 jobs:
   release:
-    name: Patch manifests and publish
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      # We use a GitHub App token (not GITHUB_TOKEN) so that publishing the
-      # release fires a `release: published` event downstream — the default
-      # GITHUB_TOKEN intentionally does not trigger further workflows, which
-      # would leave publish.yml dormant.
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-          # Scope the token to what this job does: read the draft release,
-          # replace its manifest assets and publish it.
-          permission-contents: write
-
-      - name: Resolve draft release
-        id: find
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          tag="${INPUT_TAG}"
-          if [[ -z "${tag}" ]]; then
-            # Ignore drafts whose tag was reset to an untagged-* placeholder
-            # (a stray PATCH without tag_name causes this) — publishing one
-            # would create a release under the placeholder tag.
-            tag=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first | .tag_name // ""')
-          fi
-          if [[ -z "${tag}" || "${tag}" == "null" ]]; then
-            echo "::error::No draft release found"
-            exit 1
-          fi
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
-          if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "::error::Draft release ${tag} not found"
-            exit 1
-          fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "release_id=$(echo "${release}" | jq -r '.id')" >> "$GITHUB_OUTPUT"
-          echo "url=$(echo "${release}" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
-          {
-            echo "body<<RELEASE_BODY_EOF"
-            echo "${release}" | jq -r '.body'
-            echo "RELEASE_BODY_EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Resolved draft release: ${tag}"
-
-      - name: Download manifest assets
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p assets
-          # Work with the release id resolved above instead of `gh release
-          # download <tag>`: gh's draft-by-tag resolution has proven
-          # unreliable (it caused duplicate drafts in esphome/workflows'
-          # upload-to-gh-release.yml), while lookups by id always work.
-          release_id="${{ steps.find.outputs.release_id }}"
-          if ! assets=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --paginate \
-            --jq '.[] | select(.name | endswith(".manifest.json")) | "\(.id)\t\(.name)"'); then
-            echo "::error::Failed to list draft release assets"
-            exit 1
-          fi
-          if [[ -z "${assets}" ]]; then
-            echo "::error::No *.manifest.json assets found on draft release"
-            exit 1
-          fi
-          while IFS=$'\t' read -r asset_id asset_name; do
-            echo "Downloading ${asset_name}"
-            gh api -H "Accept: application/octet-stream" \
-              "repos/${{ github.repository }}/releases/assets/${asset_id}" \
-              > "assets/${asset_name}"
-          done <<< "${assets}"
-
-      - name: Patch manifests with current release body
-        env:
-          RELEASE_SUMMARY: ${{ steps.find.outputs.body }}
-          RELEASE_URL: ${{ steps.find.outputs.url }}
-        run: |
-          set -euo pipefail
-          mkdir -p patched
-          for manifest in assets/*.manifest.json; do
-            jq --arg summary "${RELEASE_SUMMARY}" --arg url "${RELEASE_URL}" \
-              '.builds[].ota |= (.summary = $summary | .release_url = $url)' \
-              "${manifest}" > "patched/$(basename "${manifest}")"
-          done
-
-      - name: Re-upload patched manifests to draft release
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          # Upload by release id rather than `gh release upload <tag>
-          # --clobber` for the same reason as the download step: draft-by-tag
-          # resolution is unreliable. Clobber semantics are replicated by
-          # deleting any same-named asset before uploading.
-          release_id="${{ steps.find.outputs.release_id }}"
-          if ! existing=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --paginate \
-            --jq '.[] | "\(.id)\t\(.name)"'); then
-            echo "::error::Failed to list draft release assets"
-            exit 1
-          fi
-          for manifest in patched/*.manifest.json; do
-            name=$(basename "${manifest}")
-            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1}' <<< "${existing}")
-            if [[ -n "${asset_id}" ]]; then
-              echo "Deleting existing asset ${name} (${asset_id})"
-              gh api "repos/${{ github.repository }}/releases/assets/${asset_id}" \
-                --method DELETE --silent
-            fi
-            echo "Uploading ${name}"
-            gh api --method POST \
-              -H "Content-Type: application/json" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/${release_id}/assets?name=${name}" \
-              --input "${manifest}" --silent
-          done
-
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          tag="${{ steps.find.outputs.tag }}"
-          # Publish by id, not `gh release edit <tag> --draft=false`: besides
-          # the unreliable draft-by-tag resolution, gh sends a PATCH with only
-          # draft=false — and updating a draft without re-sending tag_name
-          # resets its tag to an untagged-* placeholder, which would then be
-          # published as the release tag.
-          gh api "repos/${{ github.repository }}/releases/${{ steps.find.outputs.release_id }}" \
-            --method PATCH \
-            --field "tag_name=${tag}" \
-            --field "name=${tag}" \
-            --field "draft=false" \
-            --silent
-          echo "Published ${tag} — publish.yml will pick it up via release: published"
+    name: Publish draft release
+    # Patches the draft release's manifest assets with the final release
+    # notes, then publishes it — all by release id, immune to the
+    # draft-by-tag lookup and draft-untagging API pitfalls.
+    uses: esphome/workflows/.github/workflows/publish-draft-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron: '50 18 * * *'
 
-# Only issues are processed (no stale-pr-message is configured, so
-# actions/stale never marks pull requests), so no pull-requests scope.
+# Only issues are processed (days-before-pr-stale: -1 disables pull
+# request processing entirely), so no pull-requests scope.
 permissions:
   issues: write
 
@@ -17,6 +17,7 @@ jobs:
           stale-issue-message: 'As there has been no activity on this issue for 30 days, I am marking it as stale. If you think this is a mistake, please comment below and I will remove the stale label.'
           close-issue-message: 'This issue has been closed due to inactivity. If you think this is a mistake, please comment below.'
           days-before-stale: 30
+          days-before-pr-stale: -1
           days-before-close: 5
           stale-issue-label: 'stale'
           exempt-issue-labels: 'not-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '50 18 * * *'
 
+# Only issues are processed (no stale-pr-message is configured, so
+# actions/stale never marks pull requests), so no pull-requests scope.
+permissions:
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,6 +11,9 @@ on:
       - "**.yaml"
       - "**.yml"
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: 🧹 yamllint

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ secrets.yaml
 */.gitignore
 !/.gitignore
 venv/
+.claude/


### PR DESCRIPTION
# What does this implement/fix?

Modernises this repo to the [ready-made project template](https://github.com/esphome/ready-made-project-template) standards. Releases move to the CalVer draft-release flow: release-drafter maintains a `YY.M.N` draft on every push to main, build.yml uploads firmware assets to the draft, release.yml (manual dispatch, `release` environment) patches release notes into the manifests and publishes via the ESPHome GitHub App, and publish.yml uploads to R2 and promotes to production on `release: published`. R2 uploads keep this repo's existing `directory: "."` layout (`esp-web-tools/` and `esphome-web/` as top-level directories on firmware.esphome.io).

build.yml no longer hardcodes config lists — it discovers `esp-web-tools/<chip>.yaml` and `esphome-web/<chip>.factory.yaml` by convention. `pico-2-w.factory.yaml` stays excluded (see #351) until ESPHome ≥ 2026.7.0 and an rp2-aware build-action land via a new esphome/workflows pin.

Also brings over the template's PR template, importable rulesets JSON, issue template contact links (org discussions board, fixed copy-paste errors), devcontainer image bump to `python:3.13`, a defensive `.gitignore` entry, and adds ESP32-C6 to the bug report chip dropdown.

## Types of changes

<!-- Release notes are generated from PR labels, so apply the matching label as well. -->

- [ ] Bugfix (non-breaking change which fixes an issue) — label: `bugfix`
- [ ] Enhancement (non-breaking change which improves an existing configuration) — label: `enhancement`
- [ ] Breaking change (fix or change that alters existing behaviour, e.g. renamed entities) — label: `breaking-change`
- [ ] Dependency update (actions, reusable workflows or ESPHome version) — label: `dependencies`
- [x] Other

**Related issue (if applicable):**

- fixes N/A
- closes #357
- closes #358
- closes #359
- closes #360

## Checklist

- [ ] The configuration compiles and has been tested on a real device where possible.
- [x] `yamllint --strict .` passes.

If `esphome-web` configurations were changed:

- [ ] The change was made in `scripts/generate_esphome_web_configs.py` (not by hand-editing the generated YAML) and the configs were regenerated with `python3 scripts/generate_esphome_web_configs.py`.

If a configuration was added or renamed:

- [ ] It follows the naming convention CI discovers automatically: `esp-web-tools/<chip>.yaml` or `esphome-web/<chip>.factory.yaml` — no `build.yml` edits needed.